### PR TITLE
[FFL-402] feat: ready the core package for publishing its first, empty version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,12 @@
     "url": "https://github.com/DataDog/openfeature-js-client.git",
     "directory": "packages/core"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
   "private": true,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Motivation
Receiving an `NPM_TOKEN` for publishing requires some preparation of the package so it can be manually published the first time
[Docs](https://datadoghq.atlassian.net/wiki/spaces/~194742439/pages/4180476110/Publish+a+package+on+NPM#2.-Configure-your-package)

 