### PR TITLE
fix: better package to directory mapping

### DIFF
--- a/scripts/release/generate-changelog/lib/getAffectedPackages.js
+++ b/scripts/release/generate-changelog/lib/getAffectedPackages.js
@@ -47,15 +47,13 @@ function isToplevelPackage(packageDirectoryName) {
   return !PACKAGES_REVERSE_DEPENDENCIES.has(packageDirectoryName)
 }
 
+const PACKAGE_NAME_TO_DIRECTORY = {
+  '@datadog/openfeature-browser': 'browser',
+  '@datadog/flagging-core': 'core'
+}
+
 function getPackageDirectoryNameFromPackageName(packageName) {
-  // Handle @datadog/openfeature-browser -> browser
-  if (packageName.startsWith('@datadog/openfeature-')) {
-    return packageName.slice('@datadog/openfeature-'.length)
-  }
-  // Handle @datadog/flagging-core -> core
-  if (packageName.startsWith('@datadog/flagging-')) {
-    return packageName.slice('@datadog/flagging-'.length)
-  }
+  return PACKAGE_NAME_TO_DIRECTORY[packageName]
 }
 
 function getDepenciesRecursively(packageDirectoryName) {


### PR DESCRIPTION
## Motivation
Missed a tweak in #9.

## Changes
- use a map instead of `startsWith` and `slice`
