### PR TITLE
[FFL-887] Make application ID an optional param

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ const provider = new DatadogProvider({
   // Required
   clientToken: 'pub_...', // Your Datadog client token
   // Temporary for alpha releases
-  applicationId: 'app-id', // Your application ID
+  applicationId: 'app-id', // Your application ID (optional - if provided, will be sent as dd-application-id header)
 
   // Optional Datadog configuration
   site: 'datadoghq.com', // Datadog site (datadoghq.com, datadoghq.eu, etc.)

--- a/packages/browser/src/domain/configuration.ts
+++ b/packages/browser/src/domain/configuration.ts
@@ -10,9 +10,9 @@ import { createFlagsConfigurationFetcher } from '../transport/fetchConfiguration
  */
 export interface FlaggingInitConfiguration extends InitConfiguration {
   /**
-   * The application ID for flagging.
+   * The RUM application ID.
    */
-  applicationId: string
+  applicationId?: string
 
   /**
    * Initial flags configuration (precomputed flags)

--- a/packages/browser/src/transport/fetchConfiguration.ts
+++ b/packages/browser/src/transport/fetchConfiguration.ts
@@ -36,7 +36,7 @@ export function createFlagsConfigurationFetcher(initConfiguration: FlaggingInitC
       ? {}
       : {
           'dd-client-token': initConfiguration.clientToken,
-          'dd-application-id': initConfiguration.applicationId,
+          ...(initConfiguration.applicationId && { 'dd-application-id': initConfiguration.applicationId }),
         }),
     ...initConfiguration.customHeaders,
   }


### PR DESCRIPTION
## Motivation

Working towards opening up to `client-token` authentication, the application ID is not required.

## Changes

Makes the `applicationID` param optional, and only adds the header if it is present
