### PR TITLE
Fix ESM packing

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -13,6 +13,12 @@
   "module": "esm/index.js",
   "types": "cjs/index.d.ts",
   "sideEffects": false,
+  "files": [
+    "cjs/",
+    "esm/",
+    "bundle/",
+    "*.d.ts"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,11 @@
     "url": "https://github.com/DataDog/openfeature-js-client.git",
     "directory": "packages/core"
   },
+  "files": [
+    "cjs/",
+    "esm/",
+    "*.d.ts"
+  ],
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Unblocking https://datadoghq.atlassian.net/browse/FFLNEW-734

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

Adds `files` to browser & core packages to ensure esm & cjs directory contents appear in `yarn pack`

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

Ran `yarn pack --dry-run`, saw the contents of esm/cjs directories output in the result.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Updated Documentation
- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/openfeature-js-client/blob/main/CONTRIBUTING.md -->
