### PR TITLE
v0.1.0-alpha.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ---
 
+## v0.1.0-alpha.14
+
+**Internal Changes:**
+
+- add files to browser/core package.json to (hopefully) pack esm directory for import in shopist ([#26](https://github.com/DataDog/openfeature-js-client/pull/26)) [BROWSER]
+- Add support for publishing preview releases. ([#25](https://github.com/DataDog/openfeature-js-client/pull/25))
+- bump docs for alpha 13; required & optional init ([#24](https://github.com/DataDog/openfeature-js-client/pull/24))
+
 ## v0.1.0-alpha.13
 
 **Internal Changes:**

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "npmClient": "yarn",
-  "version": "0.1.0-alpha.13"
+  "version": "0.1.0-alpha.14"
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-browser",
-  "version": "0.1.0-alpha.13",
+  "version": "0.1.0-alpha.14",
   "description": "Browser-specific bindings for OpenFeature (wraps @datadog/openfeature-core)",
   "license": "MIT",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@datadog/browser-core": "^6.17.0",
-    "@datadog/flagging-core": "0.1.0-alpha.13"
+    "@datadog/flagging-core": "0.1.0-alpha.14"
   },
   "peerDependencies": {
     "@openfeature/core": "^1.8.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/flagging-core",
-  "version": "0.1.0-alpha.13",
+  "version": "0.1.0-alpha.14",
   "description": "Runtime-agnostic flag-evaluation logic for Datadog Flagging",
   "license": "MIT",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -557,7 +557,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/flagging-core@npm:0.1.0-alpha.13, @datadog/flagging-core@workspace:packages/core":
+"@datadog/flagging-core@npm:0.1.0-alpha.14, @datadog/flagging-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@datadog/flagging-core@workspace:packages/core"
   dependencies:
@@ -581,7 +581,7 @@ __metadata:
   resolution: "@datadog/openfeature-browser@workspace:packages/browser"
   dependencies:
     "@datadog/browser-core": "npm:^6.17.0"
-    "@datadog/flagging-core": "npm:0.1.0-alpha.13"
+    "@datadog/flagging-core": "npm:0.1.0-alpha.14"
     "@openfeature/core": "npm:^1.8.1"
     "@openfeature/web-sdk": "npm:^1.5.0"
     "@types/jest": "npm:^29.4.0"


### PR DESCRIPTION
## v0.1.0-alpha.14

**Internal Changes:**

- add files to browser/core package.json to (hopefully) pack esm directory for import in shopist ([#26](https://github.com/DataDog/openfeature-js-client/pull/26)) [BROWSER]
- Add support for publishing preview releases. ([#25](https://github.com/DataDog/openfeature-js-client/pull/25))
- bump docs for alpha 13; required & optional init ([#24](https://github.com/DataDog/openfeature-js-client/pull/24))
