### PR TITLE
fix: export FlaggingInitConfiguration

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -3,6 +3,7 @@ import { DatadogProvider } from './openfeature/provider'
 
 export { DatadogProvider }
 export { configurationFromString, configurationToString } from '@datadog/flagging-core'
+export { type FlaggingInitConfiguration } from './domain/configuration'
 
 // Build environment placeholder for testing
 const SDK_VERSION = __BUILD_ENV__SDK_VERSION__


### PR DESCRIPTION
## Motivation

The main initialization options type, `FlaggingInitConfiguration` is not exported from our package, making it awkward, to say the least, to initialize the SDK in code.

## Changes

- Export the type, `FlaggingInitConfig`

_note_ The `DatadogProviderOptions` type is deprecated in favour of`FlaggingInitConfiguration` which parallels the naming for other DD browser SDKs

## Test instructions

- run `cd packages/browser; yarn build`
- verify that the type is now exported in 
  - `packages/browser/esm/index.d.ts`
  - `packages/browser/cjs/index.d.ts`

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Updated Documentation
- [ X] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/openfeature-js-client/blob/main/CONTRIBUTING.md -->
