### PR TITLE
chore: fix editor errors in jest test files

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,2 @@
 yarnPath: .yarn/releases/yarn-4.9.2.cjs
+nodeLinker: node-modules

--- a/packages/browser/test/evaluation.spec.ts
+++ b/packages/browser/test/evaluation.spec.ts
@@ -1,7 +1,7 @@
 import { configurationFromString } from '@datadog/flagging-core'
 import type { ErrorCode } from '@openfeature/web-sdk'
-import configurationWire from '../test/data/precomputed-v1-wire.json'
-import { evaluate } from './evaluation'
+import configurationWire from './data/precomputed-v1-wire.json'
+import { evaluate } from '../src/evaluation'
 
 const configuration = configurationFromString(
   // Adding stringify because import has parsed JSON

--- a/packages/browser/test/openfeature/exposures.spec.ts
+++ b/packages/browser/test/openfeature/exposures.spec.ts
@@ -1,8 +1,8 @@
 import { OpenFeature } from '@openfeature/web-sdk'
 import { INTAKE_SITE_STAGING } from '@datadog/browser-core'
-import { DatadogProvider } from './provider'
-import type { FlaggingInitConfiguration } from '../domain/configuration'
-import precomputedServerResponse from '../../test/data/precomputed-v1.json'
+import { DatadogProvider } from '../../src/openfeature/provider'
+import type { FlaggingInitConfiguration } from '../../src/domain/configuration'
+import precomputedServerResponse from '../data/precomputed-v1.json'
 
 describe('Exposures End-to-End', () => {
   let fetchMock: jest.Mock

--- a/packages/browser/test/openfeature/provider.spec.ts
+++ b/packages/browser/test/openfeature/provider.spec.ts
@@ -1,8 +1,8 @@
 import { type EvaluationContext, type Logger, StandardResolutionReasons } from '@openfeature/core'
 import { INTAKE_SITE_STAGING } from '@datadog/browser-core'
 import precomputedResponse from '../../test/data/precomputed-v1.json'
-import { DatadogProvider } from './provider'
-import { FlaggingInitConfiguration } from '../domain/configuration'
+import { DatadogProvider } from '../../src/openfeature/provider'
+import { FlaggingInitConfiguration } from '../../src/domain/configuration'
 
 describe('DatadogProvider', () => {
   let provider: DatadogProvider

--- a/packages/browser/test/transport/endpoint.spec.ts
+++ b/packages/browser/test/transport/endpoint.spec.ts
@@ -1,4 +1,4 @@
-import { buildEndpointHost } from './endpoint'
+import { buildEndpointHost } from '../../src/transport/endpoint'
 
 describe('buildEndpointHost', () => {
   describe('with default customer subdomain (preview)', () => {

--- a/packages/browser/test/transport/fetchConfiguration.spec.ts
+++ b/packages/browser/test/transport/fetchConfiguration.spec.ts
@@ -1,5 +1,5 @@
-import { createFlagsConfigurationFetcher } from './fetchConfiguration'
-import type { FlaggingInitConfiguration } from '../domain/configuration'
+import { createFlagsConfigurationFetcher } from '../../src/transport/fetchConfiguration'
+import type { FlaggingInitConfiguration } from '../../src/domain/configuration'
 import type { EvaluationContext } from '@openfeature/web-sdk'
 
 // Mock dateNow from @datadog/browser-core

--- a/packages/browser/test/tsconfig.json
+++ b/packages/browser/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../tsconfig.test.json"
+}

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "rootDir": "./src/",
     "outDir": "./dist/",
-    "types": ["jest", "node"]
+    "types": ["node"]
   },
   "include": ["./src/**/*.ts", "./src/**/*.d.ts"],
   "exclude": ["./src/**/*.spec.ts", "./src/**/*.specHelper.ts"]

--- a/packages/browser/tsconfig.test.json
+++ b/packages/browser/tsconfig.test.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "rootDir": "."
   },
-  "include": ["./src/**/*.spec.ts", "./src/**/*.test.ts", "./src/**/*.d.ts", "./src/test-setup.ts"],
+  "include": ["./src/**/*.ts", "./test/**/*.ts"],
   "exclude": []
 }


### PR DESCRIPTION
## Motivation

Fix editor errors in tests

<img width="1530" height="734" alt="Screenshot 2025-09-17 at 2 53 08 PM" src="https://github.com/user-attachments/assets/501a82dc-1729-49e5-ba7e-95ce2dc2f27e" />

## Changes

Created `packages/browser/test/tsconfig.json` file that extends `packages/browser/tsconfig.test.json` and moved all tests to `packages/browser/test/`. This allows the editor to pick up the `tsconfig.json` and apply the right config for all test files.

The alternative approach would be to ditch the `tsconfig.test.json` file entirely and co-locate test files next to the production files, sharing the same TypeScript configuration. Webpack would ensure the test files get cleaned up before packaging. I'd be fine with this approach as well if that's the team's preference.