### PR TITLE
chore: fix release jobs with newly added token

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   validate-release:
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -35,6 +36,7 @@ jobs:
 
   build-and-publish:
     runs-on: ubuntu-latest
+    environment: production
     needs: validate-release
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Motivation

[release actions are failing](https://github.com/DataDog/openfeature-js-client/actions/runs/17956372252/job/51068632314).

## Changes

Adds `environment: production` per @vinvol 's recommendation

