### PR TITLE
fix: hooks availability in node sdk

### DIFF
--- a/packages/node-server/src/provider.ts
+++ b/packages/node-server/src/provider.ts
@@ -35,12 +35,13 @@ export class DatadogNodeServerProvider implements Provider {
     name: 'datadog-node-server',
   }
   readonly runsOn: Paradigm = 'server'
-  readonlyhooks?: Hook[]
+  readonly hooks?: Hook[]
 
   status: ProviderStatus = ProviderStatus.NOT_READY
   private configuration?: UniversalFlagConfigurationV1 | undefined
 
   constructor(private readonly options: DatadogNodeServerProviderOptions) {
+    this.hooks = []
     this.configuration = options.configuration
     if (this.configuration) {
       this.status = ProviderStatus.READY

--- a/packages/node-server/test/provider.spec.ts
+++ b/packages/node-server/test/provider.spec.ts
@@ -1,4 +1,14 @@
-import { ProviderStatus } from '@openfeature/server-sdk'
+import {
+  FlagValue,
+  HookContext,
+  Logger,
+  OpenFeature,
+  ProviderStatus,
+  Hook,
+  EvaluationDetails,
+  HookHints,
+  BaseHook,
+} from '@openfeature/server-sdk'
 import { DatadogNodeServerProvider } from '../src/provider'
 import { UniversalFlagConfigurationV1, UniversalFlagConfigurationV1Response } from 'src/configuration/ufc-v1'
 import fs from 'fs'
@@ -7,6 +17,8 @@ import { Channel } from 'diagnostics_channel'
 import { ExposureEvent } from '@datadog/flagging-core/src/configuration/exposureEvent.types'
 
 describe('DatadogNodeServerProvider', () => {
+  let logger: Logger
+
   const mockExposureChannel: Channel<ExposureEvent, ExposureEvent> = {
     hasSubscribers: true,
     publish: jest.fn(),
@@ -18,6 +30,15 @@ describe('DatadogNodeServerProvider', () => {
     const ufcResponse = JSON.parse(ufcJson) as UniversalFlagConfigurationV1Response
     return ufcResponse.data.attributes
   })()
+
+  beforeEach(() => {
+    logger = {
+      error: console.error,
+      warn: console.warn,
+      info: console.info,
+      debug: jest.fn(),
+    }
+  })
 
   it('should should be ready when configuration is provided', () => {
     const provider = new DatadogNodeServerProvider({
@@ -51,5 +72,31 @@ describe('DatadogNodeServerProvider', () => {
     expect(provider.status).toBe(ProviderStatus.READY)
     provider.setConfiguration(undefined)
     expect(provider.status).toBe(ProviderStatus.NOT_READY)
+  })
+
+  it('should allow hooks to be set', async () => {
+    const provider = new DatadogNodeServerProvider({
+      configuration: configuration,
+      exposureChannel: mockExposureChannel,
+    })
+    OpenFeature.setProvider(provider)
+    OpenFeature.setLogger(logger)
+    OpenFeature.setContext({ targetingKey: 'test-user-123' })
+    const client = OpenFeature.getClient()
+    const afterHook = jest.fn()
+    const testHook: BaseHook = {
+      after: (
+        hookContext: HookContext<FlagValue>,
+        evaluationDetails: EvaluationDetails<FlagValue>,
+        hookHints?: HookHints
+      ) => {
+        afterHook(hookContext, evaluationDetails, hookHints)
+      },
+    }
+    client.addHooks(testHook)
+
+    await client.getBooleanDetails('test-flag', false)
+
+    expect(afterHook).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Motivation

Fix typo when defining hooks. Hooks actually still work even before this fix, but it'd be good to fix the typo and ensure that hooks are readonly for typescript consumers so that they use the built-in addHooks() method. This isn't urgent for immediate release.