### PR TITLE
fix: include spark-md5 in the correct package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
     "@types/node": "^20.0.0",
-    "@types/spark-md5": "^3.0.5",
     "glob": "^11.0.3",
     "jest": "^30.0.4",
     "lerna": "^8.2.3",
@@ -40,7 +39,6 @@
   },
   "packageManager": "yarn@4.9.2",
   "dependencies": {
-    "emoji-name-map": "^2.0.3",
-    "spark-md5": "^3.0.2"
+    "emoji-name-map": "^2.0.3"
   }
 }

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -34,7 +34,8 @@
   },
   "dependencies": {
     "@datadog/flagging-core": "0.1.0-preview.6",
-    "@openfeature/server-sdk": "^1.19.0"
+    "@openfeature/server-sdk": "^1.19.0",
+    "spark-md5": "^3.0.2"
   },
   "peerDependencies": {
     "@openfeature/server-sdk": "^1.19.0"
@@ -43,6 +44,7 @@
     "@openfeature/core": "^1.9.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^20.0.0",
+    "@types/spark-md5": "^3",
     "jest": "^30.0.4",
     "npm-run-all": "^4.1.5",
     "ts-jest": "^29.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,7 +606,6 @@ __metadata:
   dependencies:
     "@biomejs/biome": "npm:^2.0.0"
     "@types/node": "npm:^20.0.0"
-    "@types/spark-md5": "npm:^3.0.5"
     emoji-name-map: "npm:^2.0.3"
     glob: "npm:^11.0.3"
     jest: "npm:^30.0.4"
@@ -614,7 +613,6 @@ __metadata:
     npm-run-all: "npm:^4.1.5"
     prettier: "npm:^3.6.2"
     rimraf: "npm:^6.0.0"
-    spark-md5: "npm:^3.0.2"
     terser-webpack-plugin: "npm:^5.3.14"
     ts-loader: "npm:^9.5.2"
     ts-node: "npm:^10.9.0"
@@ -633,8 +631,10 @@ __metadata:
     "@openfeature/server-sdk": "npm:^1.19.0"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^20.0.0"
+    "@types/spark-md5": "npm:^3"
     jest: "npm:^30.0.4"
     npm-run-all: "npm:^4.1.5"
+    spark-md5: "npm:^3.0.2"
     ts-jest: "npm:^29.4.0"
     ts-loader: "npm:^9.5.2"
     typescript: "npm:^5.5.0"
@@ -2089,7 +2089,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/spark-md5@npm:^3.0.5":
+"@types/spark-md5@npm:^3":
   version: 3.0.5
   resolution: "@types/spark-md5@npm:3.0.5"
   checksum: 10c0/501b6aa80fc6d8504fb0ad961c28b2f99d7fc3d7769059f113b4060334623b6c8da7f21dac984211d7d819ac7170ee3ce47dba682453b6baff79052fe382d810


### PR DESCRIPTION
## Motivation

spark-md5 was incorrectly added to the root-level package.json instead of the node-server package.json. This caused dd-trace-js to not include spark-md5 after installing it. Tested locally by installing into an example node app via `npm pack`.