### PR TITLE
chore: fix linting and formatting issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Lint
+        run: yarn lint
+
       - name: Build packages
         run: yarn build
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,5 @@ bundle/
 
 # IDEs
 .idea/
-.vscode/
 .DS_Store
 .env

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "arcanis.vscode-zipfs",
+    "esbenp.prettier-vscode",
+    "biomejs.biome"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,26 @@
+{
+  "search.exclude": {
+    "**/.yarn": true,
+    "**/.pnp.*": true,
+    "**/dist": true,
+    "**/cjs": true,
+    "**/esm": true,
+    "**/bundle": true
+  },
+  "prettier.requireConfig": true,
+  "typescript.tsdk": ".yarn/sdks/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "editor.formatOnSave": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/biome.json
+++ b/biome.json
@@ -3,14 +3,14 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "correctness": {
+        "noUnusedImports": "error"
+      }
     }
   },
   "formatter": {
-    "enabled": true,
-    "indentStyle": "space",
-    "indentWidth": 2,
-    "lineWidth": 80
+    "enabled": false
   },
   "javascript": {
     "formatter": {
@@ -28,6 +28,6 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**", "!**/dist", "!**/cjs", "!.pnp.*"]
+    "includes": ["**", "!**/dist", "!**/cjs", "!**/esm", "!.pnp.*", "!**/bundle"]
   }
 }

--- a/packages/browser/src/domain/configuration.ts
+++ b/packages/browser/src/domain/configuration.ts
@@ -1,8 +1,8 @@
 import type { Configuration, InitConfiguration } from '@datadog/browser-core'
-import { validateAndBuildConfiguration, display } from '@datadog/browser-core'
-import type { DDRum } from '../openfeature/rumIntegration'
+import { display, validateAndBuildConfiguration } from '@datadog/browser-core'
 import type { FlagsConfiguration } from '@datadog/flagging-core'
 import type { EvaluationContext } from '@openfeature/web-sdk'
+import type { DDRum } from '../openfeature/rumIntegration'
 import { createFlagsConfigurationFetcher } from '../transport/fetchConfiguration'
 
 /**

--- a/packages/browser/src/evaluation.ts
+++ b/packages/browser/src/evaluation.ts
@@ -1,6 +1,6 @@
 import type { FlagsConfiguration, FlagTypeToValue, PrecomputedConfiguration } from '@datadog/flagging-core'
-import type { ErrorCode, EvaluationContext, FlagValueType, ResolutionDetails } from '@openfeature/web-sdk'
 import type { PrecomputedFlagMetadata } from '@datadog/flagging-core/src/configuration/configuration'
+import type { ErrorCode, EvaluationContext, FlagValueType, ResolutionDetails } from '@openfeature/web-sdk'
 
 export function evaluate<T extends FlagValueType>(
   flagsConfiguration: FlagsConfiguration,

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -3,9 +3,9 @@ import { DatadogProvider } from './openfeature/provider'
 
 export { DatadogProvider }
 export { configurationFromString, configurationToString } from '@datadog/flagging-core'
-export { type FlaggingInitConfiguration } from './domain/configuration'
+export type { FlaggingInitConfiguration } from './domain/configuration'
 
 // Build environment placeholder for testing
-const SDK_VERSION = __BUILD_ENV__SDK_VERSION__
+const _SDK_VERSION = __BUILD_ENV__SDK_VERSION__
 
 defineGlobal(getGlobalObject(), 'DD_FLAGGING' as keyof typeof globalThis, { Provider: DatadogProvider })

--- a/packages/browser/src/openfeature/exposures.ts
+++ b/packages/browser/src/openfeature/exposures.ts
@@ -1,10 +1,10 @@
-import { dateNow, createPageMayExitObservable, addTelemetryDebug } from '@datadog/browser-core'
 import type { Context, RawError } from '@datadog/browser-core'
+import { addTelemetryDebug, createPageMayExitObservable, dateNow } from '@datadog/browser-core'
+import { createExposureEvent } from '@datadog/flagging-core/src/configuration/exposureEvent'
 import type { EvaluationDetails, FlagValue, Hook, HookContext } from '@openfeature/web-sdk'
+import type { FlaggingConfiguration } from '../domain/configuration'
 import { startExposuresBatch } from '../transport/startExposuresBatch'
 import type { DDRum } from './rumIntegration'
-import type { FlaggingConfiguration } from '../domain/configuration'
-import { createExposureEvent } from '@datadog/flagging-core/src/configuration/exposureEvent'
 
 /**
  * Create hook for RUM flag tracking

--- a/packages/browser/src/openfeature/provider.ts
+++ b/packages/browser/src/openfeature/provider.ts
@@ -1,4 +1,4 @@
-import type { InitConfiguration } from '@datadog/browser-core'
+
 import type { FlagsConfiguration } from '@datadog/flagging-core'
 import type {
   EvaluationContext,
@@ -12,14 +12,13 @@ import type {
 } from '@openfeature/web-sdk'
 /* eslint-disable-next-line local-rules/disallow-side-effects */
 import { ProviderStatus } from '@openfeature/web-sdk'
-import { evaluate } from '../evaluation'
-import { createRumTrackingHook, createRumExposureHook, createExposureLoggingHook } from './exposures'
-import type { DDRum } from './rumIntegration'
 import {
-  validateAndBuildFlaggingConfiguration,
-  type FlaggingInitConfiguration,
   type FlaggingConfiguration,
+  type FlaggingInitConfiguration,
+  validateAndBuildFlaggingConfiguration,
 } from '../domain/configuration'
+import { evaluate } from '../evaluation'
+import { createExposureLoggingHook, createRumExposureHook, createRumTrackingHook } from './exposures'
 
 /**
  * @deprecated Use FlaggingInitConfiguration instead

--- a/packages/browser/src/transport/endpoint.ts
+++ b/packages/browser/src/transport/endpoint.ts
@@ -30,5 +30,5 @@ export function buildEndpointHost(site: string, customerDomain = 'preview'): str
   // ff-cdn is the subdomain pointing to the CDN servers
   // dc is the datacenter, if specified
   // tld is the top level domain, changes for eu DCs
-  return `${customerDomain}.ff-cdn.${dc ? dc + '.' : ''}datadoghq.${tld}`
+  return `${customerDomain}.ff-cdn.${dc ? `${dc}.` : ''}datadoghq.${tld}`
 }

--- a/packages/browser/src/transport/fetchConfiguration.ts
+++ b/packages/browser/src/transport/fetchConfiguration.ts
@@ -11,7 +11,7 @@ const sdkPayload = {
 
 export function createFlagsConfigurationFetcher(initConfiguration: FlaggingInitConfiguration) {
   let url: URL
-  if (initConfiguration.flaggingProxy && initConfiguration.flaggingProxy.match('https?://')) {
+  if (initConfiguration.flaggingProxy?.match('https?://')) {
     // If flaggingProxy has a protocol, use it as-is
     url = new URL(`${initConfiguration.flaggingProxy}`)
   } else if (initConfiguration.flaggingProxy) {

--- a/packages/browser/src/transport/startExposuresBatch.ts
+++ b/packages/browser/src/transport/startExposuresBatch.ts
@@ -1,9 +1,9 @@
-import type { Context, PageMayExitEvent, RawError } from '@datadog/browser-core'
+import type { PageMayExitEvent, RawError } from '@datadog/browser-core'
 import {
-  createIdentityEncoder,
-  createFlushController,
   createBatch,
+  createFlushController,
   createHttpRequest,
+  createIdentityEncoder,
   Observable,
 } from '@datadog/browser-core'
 import type { FlaggingConfiguration } from '../domain/configuration'

--- a/packages/browser/test/evaluation.spec.ts
+++ b/packages/browser/test/evaluation.spec.ts
@@ -1,7 +1,7 @@
 import { configurationFromString } from '@datadog/flagging-core'
 import type { ErrorCode } from '@openfeature/web-sdk'
-import configurationWire from './data/precomputed-v1-wire.json'
 import { evaluate } from '../src/evaluation'
+import configurationWire from './data/precomputed-v1-wire.json'
 
 const configuration = configurationFromString(
   // Adding stringify because import has parsed JSON
@@ -55,7 +55,7 @@ describe('evaluate', () => {
   })
 
   it('resolves object flag', () => {
-    const result = evaluate<any>(configuration, 'object', 'json-flag', { hello: 'world' }, {})
+    const result = evaluate<'object'>(configuration, 'object', 'json-flag', { hello: 'world' }, {})
     expect(result).toEqual({
       value: { key: 'value', prop: 123 },
       variant: 'variation-127',

--- a/packages/browser/test/openfeature/exposures.spec.ts
+++ b/packages/browser/test/openfeature/exposures.spec.ts
@@ -1,7 +1,7 @@
-import { OpenFeature } from '@openfeature/web-sdk'
 import { INTAKE_SITE_STAGING } from '@datadog/browser-core'
-import { DatadogProvider } from '../../src/openfeature/provider'
+import { OpenFeature } from '@openfeature/web-sdk'
 import type { FlaggingInitConfiguration } from '../../src/domain/configuration'
+import { DatadogProvider } from '../../src/openfeature/provider'
 import precomputedServerResponse from '../data/precomputed-v1.json'
 
 describe('Exposures End-to-End', () => {

--- a/packages/browser/test/openfeature/provider.spec.ts
+++ b/packages/browser/test/openfeature/provider.spec.ts
@@ -1,8 +1,8 @@
-import { type EvaluationContext, type Logger, StandardResolutionReasons } from '@openfeature/core'
 import { INTAKE_SITE_STAGING } from '@datadog/browser-core'
-import precomputedResponse from '../../test/data/precomputed-v1.json'
+import { type EvaluationContext, type Logger, StandardResolutionReasons } from '@openfeature/core'
+import type { FlaggingInitConfiguration } from '../../src/domain/configuration'
 import { DatadogProvider } from '../../src/openfeature/provider'
-import { FlaggingInitConfiguration } from '../../src/domain/configuration'
+import precomputedResponse from '../../test/data/precomputed-v1.json'
 
 describe('DatadogProvider', () => {
   let provider: DatadogProvider

--- a/packages/browser/test/transport/fetchConfiguration.spec.ts
+++ b/packages/browser/test/transport/fetchConfiguration.spec.ts
@@ -1,6 +1,6 @@
-import { createFlagsConfigurationFetcher } from '../../src/transport/fetchConfiguration'
-import type { FlaggingInitConfiguration } from '../../src/domain/configuration'
 import type { EvaluationContext } from '@openfeature/web-sdk'
+import type { FlaggingInitConfiguration } from '../../src/domain/configuration'
+import { createFlagsConfigurationFetcher } from '../../src/transport/fetchConfiguration'
 
 // Mock dateNow from @datadog/browser-core
 jest.mock('@datadog/browser-core', () => ({

--- a/packages/browser/webpack.config.js
+++ b/packages/browser/webpack.config.js
@@ -1,4 +1,4 @@
-const path = require('path')
+const path = require('node:path')
 
 const webpackBase = require('../../webpack.base')
 

--- a/packages/core/src/configuration/configuration.ts
+++ b/packages/core/src/configuration/configuration.ts
@@ -18,10 +18,10 @@ export type PrecomputedConfiguration = {
 // Fancy way to map FlagValueType to expected FlagValue.
 /** @internal */
 export type FlagTypeToValue<T extends FlagValueType> = {
-  ['boolean']: boolean
-  ['string']: string
-  ['number']: number
-  ['object']: JsonValue
+  'boolean': boolean
+  'string': string
+  'number': number
+  'object': JsonValue
 }[T]
 
 /** @internal

--- a/packages/core/src/configuration/exposureEvent.ts
+++ b/packages/core/src/configuration/exposureEvent.ts
@@ -1,5 +1,5 @@
-import { EvaluationContext, EvaluationDetails, FlagValue } from '@openfeature/core'
-import { ExposureEvent } from './exposureEvent.types'
+import type { EvaluationContext, EvaluationDetails, FlagValue } from '@openfeature/core'
+import type { ExposureEvent } from './exposureEvent.types'
 
 export function createExposureEvent<T extends FlagValue>(
   context: EvaluationContext,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
 export * from './configuration'
 
 // Build environment placeholder for testing
-const SDK_VERSION = __BUILD_ENV__SDK_VERSION__
+const _SDK_VERSION = __BUILD_ENV__SDK_VERSION__

--- a/packages/node-server/src/configuration/evaluateForSubject.ts
+++ b/packages/node-server/src/configuration/evaluateForSubject.ts
@@ -1,15 +1,15 @@
-import { matchesRule, Rule } from '../rules/rules'
-import { matchesShard } from '../shards/matchesShard'
-import { Flag, Split, VariantType, variantTypeToFlagValueType } from './ufc-v1'
+import type { FlagTypeToValue, PrecomputedFlagMetadata } from '@datadog/flagging-core'
 import {
   ErrorCode,
-  EvaluationContext,
-  FlagValueType,
-  Logger,
-  ResolutionDetails,
+  type EvaluationContext,
+  type FlagValueType,
+  type Logger,
+  type ResolutionDetails,
   StandardResolutionReasons,
 } from '@openfeature/server-sdk'
-import { FlagTypeToValue, PrecomputedFlagMetadata } from '@datadog/flagging-core'
+import { matchesRule, type Rule } from '../rules/rules'
+import { matchesShard } from '../shards/matchesShard'
+import { type Flag, type Split, type VariantType, variantTypeToFlagValueType } from './ufc-v1'
 
 export function evaluateForSubject<T extends FlagValueType>(
   flag: Flag | undefined,

--- a/packages/node-server/src/configuration/evaluation.ts
+++ b/packages/node-server/src/configuration/evaluation.ts
@@ -1,14 +1,14 @@
 import type { FlagTypeToValue } from '@datadog/flagging-core'
 import {
   ErrorCode,
-  EvaluationContext,
-  FlagValueType,
-  Logger,
-  ResolutionDetails,
+  type EvaluationContext,
+  type FlagValueType,
+  type Logger,
+  type ResolutionDetails,
   StandardResolutionReasons,
 } from '@openfeature/server-sdk'
-import { UniversalFlagConfigurationV1 } from './ufc-v1'
 import { evaluateForSubject } from './evaluateForSubject'
+import type { UniversalFlagConfigurationV1 } from './ufc-v1'
 
 export function evaluate<T extends FlagValueType>(
   config: UniversalFlagConfigurationV1 | undefined,

--- a/packages/node-server/src/configuration/ufc-v1.ts
+++ b/packages/node-server/src/configuration/ufc-v1.ts
@@ -1,5 +1,5 @@
-import { FlagValue, FlagValueType } from '@openfeature/core'
-import { Rule } from '../rules/rules'
+import type { FlagValue, FlagValueType } from '@openfeature/core'
+import type { Rule } from '../rules/rules'
 
 export type VariantType = 'BOOLEAN' | 'INTEGER' | 'NUMERIC' | 'STRING' | 'JSON'
 

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -1,4 +1,4 @@
 export * from './provider'
 
 // Build environment placeholder for testing
-const SDK_VERSION = __BUILD_ENV__SDK_VERSION__
+const _SDK_VERSION = __BUILD_ENV__SDK_VERSION__

--- a/packages/node-server/src/provider.ts
+++ b/packages/node-server/src/provider.ts
@@ -1,24 +1,21 @@
+import type { Channel } from 'node:diagnostics_channel'
+import { createExposureEvent, type ExposureEvent } from '@datadog/flagging-core'
+import type { EvaluationContext } from '@openfeature/core'
 import type {
   EvaluationDetails,
+  FlagValue,
+  Hook,
   JsonValue,
   Logger,
+  Paradigm,
   Provider,
+  ProviderEventEmitter,
   ProviderMetadata,
   ResolutionDetails,
-  Paradigm,
-  Hook,
-  FlagValue,
-  ProviderEventEmitter,
 } from '@openfeature/server-sdk'
-
 import { OpenFeatureEventEmitter, ProviderEvents } from '@openfeature/server-sdk'
-
-import { EvaluationContext } from '@openfeature/core'
 import { evaluate } from './configuration/evaluation'
-import { UniversalFlagConfigurationV1 } from './configuration/ufc-v1'
-import { ExposureEvent } from '@datadog/flagging-core'
-import { createExposureEvent } from '@datadog/flagging-core'
-import type { Channel } from 'node:diagnostics_channel'
+import type { UniversalFlagConfigurationV1 } from './configuration/ufc-v1'
 
 export interface DatadogNodeServerProviderOptions {
   /**

--- a/packages/node-server/src/rules/rules.ts
+++ b/packages/node-server/src/rules/rules.ts
@@ -1,4 +1,4 @@
-import { EvaluationContext, EvaluationContextValue } from '@openfeature/server-sdk'
+import type { EvaluationContext, EvaluationContextValue } from '@openfeature/server-sdk'
 
 export type ConditionValueType = EvaluationContextValue | EvaluationContextValue[]
 

--- a/packages/node-server/src/shards/matchesShard.ts
+++ b/packages/node-server/src/shards/matchesShard.ts
@@ -1,5 +1,5 @@
-import { Shard, ShardRange } from '../configuration/ufc-v1'
-import { MD5Sharder, Sharder } from './sharders'
+import type { Shard, ShardRange } from '../configuration/ufc-v1'
+import { MD5Sharder, type Sharder } from './sharders'
 
 export function matchesShard(shard: Shard, subjectKey: string, customSharder?: Sharder): boolean {
   const sharder = customSharder ?? new MD5Sharder()

--- a/packages/node-server/test/TestCaseResult.types.ts
+++ b/packages/node-server/test/TestCaseResult.types.ts
@@ -1,6 +1,6 @@
-import { EvaluationContextValue, FlagValue } from '@openfeature/server-sdk'
-import { VariantType } from '../src/configuration/ufc-v1'
-import { PrecomputedFlagMetadata } from '@datadog/flagging-core'
+import type { PrecomputedFlagMetadata } from '@datadog/flagging-core'
+import type { EvaluationContextValue, FlagValue } from '@openfeature/server-sdk'
+import type { VariantType } from '../src/configuration/ufc-v1'
 
 export interface TestCase {
   flag: string

--- a/packages/node-server/test/flags-v1.spec.ts
+++ b/packages/node-server/test/flags-v1.spec.ts
@@ -1,12 +1,12 @@
+import type { Channel } from 'node:diagnostics_channel'
+import fs from 'node:fs'
+import path from 'node:path'
+import type { ExposureEvent } from '@datadog/flagging-core'
 import type { EvaluationContext, EvaluationDetails, FlagValue, JsonValue, Logger } from '@openfeature/core'
 import { OpenFeature } from '@openfeature/server-sdk'
-import fs from 'fs'
-import { Channel } from 'node:diagnostics_channel'
-import path from 'path'
-import { UniversalFlagConfigurationV1, UniversalFlagConfigurationV1Response } from '../src/configuration/ufc-v1'
+import type { UniversalFlagConfigurationV1, UniversalFlagConfigurationV1Response } from '../src/configuration/ufc-v1'
 import { DatadogNodeServerProvider } from '../src/provider'
-import { TestCase } from './TestCaseResult.types'
-import { ExposureEvent } from '@datadog/flagging-core'
+import type { TestCase } from './TestCaseResult.types'
 
 type ExposureChannelListener = (message: ExposureEvent, name: string | symbol) => void
 

--- a/packages/node-server/test/provider.spec.ts
+++ b/packages/node-server/test/provider.spec.ts
@@ -1,21 +1,19 @@
+import type { Channel } from 'node:diagnostics_channel'
+import fs from 'node:fs'
+import path from 'node:path'
+import type { ExposureEvent } from '@datadog/flagging-core'
 import {
-  FlagValue,
-  HookContext,
-  Logger,
+  type BaseHook,
+  type EvaluationDetails,
+  type FlagValue,
+  type HookContext,
+  type HookHints,
+  type Logger,
   OpenFeature,
-  ProviderStatus,
-  Hook,
-  EvaluationDetails,
-  HookHints,
-  BaseHook,
   ProviderEvents,
 } from '@openfeature/server-sdk'
+import type { UniversalFlagConfigurationV1, UniversalFlagConfigurationV1Response } from 'src/configuration/ufc-v1'
 import { DatadogNodeServerProvider } from '../src/provider'
-import { UniversalFlagConfigurationV1, UniversalFlagConfigurationV1Response } from 'src/configuration/ufc-v1'
-import fs from 'fs'
-import path from 'path'
-import { Channel } from 'diagnostics_channel'
-import { ExposureEvent } from '@datadog/flagging-core'
 
 describe('DatadogNodeServerProvider', () => {
   let logger: Logger

--- a/scripts/lib/buildEnv.js
+++ b/scripts/lib/buildEnv.js
@@ -1,7 +1,6 @@
-const { readFileSync } = require('fs')
-const path = require('path')
-const execSync = require('child_process').execSync
-const { command } = require('./executionUtils')
+const { readFileSync } = require('node:fs')
+const path = require('node:path')
+const execSync = require('node:child_process').execSync
 
 /**
  * Allows to define which sdk_version to send to the intake.

--- a/scripts/lib/executionUtils.js
+++ b/scripts/lib/executionUtils.js
@@ -1,4 +1,4 @@
-const { spawn } = require('child_process')
+const { spawn } = require('node:child_process')
 
 function runMain(main) {
   Promise.resolve()
@@ -47,7 +47,7 @@ function command(strings, ...values) {
 
 // Synchronous command execution that returns stdout
 function syncCommand(command) {
-  const { execSync } = require('child_process')
+  const { execSync } = require('node:child_process')
   return execSync(command, { encoding: 'utf-8' }).trim()
 }
 

--- a/scripts/lib/filesUtils.js
+++ b/scripts/lib/filesUtils.js
@@ -1,6 +1,6 @@
-const fs = require('fs')
-const path = require('path')
-const fsPromises = require('fs/promises')
+const fs = require('node:fs')
+const path = require('node:path')
+const fsPromises = require('node:fs/promises')
 const { command } = require('./executionUtils')
 
 /**

--- a/scripts/release/generate-changelog/lib/addNewChangesToChangelog.js
+++ b/scripts/release/generate-changelog/lib/addNewChangesToChangelog.js
@@ -1,5 +1,5 @@
-const { readFile } = require('fs/promises')
-const fs = require('fs')
+const { readFile } = require('node:fs/promises')
+const fs = require('node:fs')
 
 const emojiNameMap = require('emoji-name-map')
 

--- a/scripts/release/generate-changelog/lib/getAffectedPackages.js
+++ b/scripts/release/generate-changelog/lib/getAffectedPackages.js
@@ -1,4 +1,4 @@
-const fs = require('fs')
+const fs = require('node:fs')
 const { packagesDirectoryNames } = require('../../../lib/packagesDirectoryNames')
 const { commandSync } = require('../../../lib/executionUtils')
 
@@ -68,7 +68,7 @@ function getDepenciesRecursively(packageDirectoryName) {
       const packageDirectoryName = getPackageDirectoryNameFromPackageName(dependencyPackageName)
       if (packageDirectoryName) {
         dependencies.add(packageDirectoryName)
-        for (let transitiveDependency of getDepenciesRecursively(packageDirectoryName)) {
+        for (const transitiveDependency of getDepenciesRecursively(packageDirectoryName)) {
           dependencies.add(transitiveDependency)
         }
       }

--- a/scripts/webpack-runner.js
+++ b/scripts/webpack-runner.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const webpack = require('webpack')
-const path = require('path')
+const path = require('node:path')
 
 // Get the webpack config path from command line arguments
 const configPath = process.argv[2]

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -1,4 +1,4 @@
-const path = require('path')
+const path = require('node:path')
 const webpack = require('webpack')
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')


### PR DESCRIPTION
## Motivation

- 301 linting errors before this change
- Linting not happening in CI
- Biome was configured for formatting and so was prettier
- VSCode/Cursor did not have workspace configurations creating misalignment on formatting and linting

## Changes

Fixed all of the aforementioned issues
- Added Linting to CI
- Fixed existing lint rules
- Disabled Biome as a formatter since we already have prettier for that purpose
- Configured formatters in workspace settings to reduce confusion
- Added Biome as a recommended VSCode/Cursor extension

## Test instructions

`yarn lint`