### PR TITLE
fix: remove @openfeature/web-sdk dependency in core sdk

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,3 @@
 {
-  "recommendations": [
-    "arcanis.vscode-zipfs",
-    "esbenp.prettier-vscode",
-    "biomejs.biome"
-  ]
+  "recommendations": ["arcanis.vscode-zipfs", "esbenp.prettier-vscode", "biomejs.biome"]
 }

--- a/packages/browser/src/openfeature/provider.ts
+++ b/packages/browser/src/openfeature/provider.ts
@@ -1,4 +1,3 @@
-
 import type { FlagsConfiguration } from '@datadog/flagging-core'
 import type {
   EvaluationContext,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@openfeature/core": "^1.8.1",
-    "@openfeature/web-sdk": "^1.5.0",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.0.0",
     "jest": "^30.0.4",
@@ -43,7 +42,6 @@
     "typescript": "^5.5.0"
   },
   "peerDependencies": {
-    "@openfeature/core": "^1.8.1",
-    "@openfeature/web-sdk": "^1.5.0"
+    "@openfeature/core": "^1.8.1"
   }
 }

--- a/packages/core/src/configuration/configuration.ts
+++ b/packages/core/src/configuration/configuration.ts
@@ -1,4 +1,4 @@
-import type { EvaluationContext, FlagValueType, JsonValue, ResolutionReason } from '@openfeature/web-sdk'
+import type { EvaluationContext, FlagValueType, JsonValue, ResolutionReason } from '@openfeature/core'
 
 /**
  * Internal flags configuration for DatadogProvider.
@@ -18,10 +18,10 @@ export type PrecomputedConfiguration = {
 // Fancy way to map FlagValueType to expected FlagValue.
 /** @internal */
 export type FlagTypeToValue<T extends FlagValueType> = {
-  'boolean': boolean
-  'string': string
-  'number': number
-  'object': JsonValue
+  boolean: boolean
+  string: string
+  number: number
+  object: JsonValue
 }[T]
 
 /** @internal

--- a/packages/core/src/configuration/wire.ts
+++ b/packages/core/src/configuration/wire.ts
@@ -1,4 +1,4 @@
-import type { EvaluationContext } from '@openfeature/web-sdk'
+import type { EvaluationContext } from '@openfeature/core'
 
 import type { FlagsConfiguration, UnixTimestamp } from './configuration'
 

--- a/packages/node-server/src/index.ts
+++ b/packages/node-server/src/index.ts
@@ -1,3 +1,4 @@
+export type { UniversalFlagConfigurationV1 } from './configuration/ufc-v1'
 export * from './provider'
 
 // Build environment placeholder for testing

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,7 +562,6 @@ __metadata:
   resolution: "@datadog/flagging-core@workspace:packages/core"
   dependencies:
     "@openfeature/core": "npm:^1.8.1"
-    "@openfeature/web-sdk": "npm:^1.5.0"
     "@types/jest": "npm:^29.4.0"
     "@types/node": "npm:^18.0.0"
     jest: "npm:^30.0.4"
@@ -572,7 +571,6 @@ __metadata:
     typescript: "npm:^5.5.0"
   peerDependencies:
     "@openfeature/core": ^1.8.1
-    "@openfeature/web-sdk": ^1.5.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Motivation

Without this change, importing certain functionality causes type errors for consumers that do not have `@openfeature/web-sdk` installed.

```
tsc -p . && tsc --types node test
../node_modules/@datadog/flagging-core/cjs/configuration/configuration.d.ts:1:84 - error TS2307: Cannot find module '@openfeature/web-sdk' or its corresponding type declarations.
```

## Changes

Removed `@openfeature/web-sdk` as a dependency of the core package. It was not needed since the types that were used were already in the `@openfeature/core` package.

