### PR TITLE
feat: in-memory exposure caching for server SDK

### DIFF
--- a/packages/core/src/cache/index.ts
+++ b/packages/core/src/cache/index.ts
@@ -1,2 +1,3 @@
 export * from './abstract-assignment-cache'
+export * from './lru-in-memory-assignment-cache'
 export * from './non-expiring-in-memory-cache-assignment'

--- a/packages/core/src/cache/lru-cache.ts
+++ b/packages/core/src/cache/lru-cache.ts
@@ -1,0 +1,97 @@
+/**
+ * LRUCache is a simple implementation of a Least Recently Used (LRU) cache.
+ *
+ * Old items are evicted when the cache reaches its capacity.
+ *
+ * The cache is implemented as a Map, which maintains insertion order:
+ * ```
+ * Iteration happens in insertion order, which corresponds to the order in which each key-value pair
+ * was first inserted into the map by the set() method (that is, there wasn't a key with the same
+ * value already in the map when set() was called).
+ * ```
+ * Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
+ */
+export class LRUCache implements Map<string, string> {
+  protected readonly cache = new Map<string, string>();
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  [Symbol.toStringTag]: string
+
+  constructor(protected readonly capacity: number) {}
+
+  [Symbol.iterator](): IterableIterator<[string, string]> {
+    return this.cache[Symbol.iterator]()
+  }
+
+  forEach(callbackFn: (value: string, key: string, map: Map<string, string>) => void): void {
+    this.cache.forEach(callbackFn)
+  }
+
+  readonly size: number = this.cache.size
+
+  entries(): IterableIterator<[string, string]> {
+    return this.cache.entries()
+  }
+
+  clear() {
+    this.cache.clear()
+  }
+
+  delete(key: string): boolean {
+    return this.cache.delete(key)
+  }
+
+  keys(): IterableIterator<string> {
+    return this.cache.keys()
+  }
+
+  values(): IterableIterator<string> {
+    return this.cache.values()
+  }
+
+  has(key: string): boolean {
+    return this.cache.has(key)
+  }
+
+  get(key: string): string | undefined {
+    if (!this.has(key)) {
+      return undefined
+    }
+
+    const value = this.cache.get(key)
+
+    if (value !== undefined) {
+      // the delete and set operations are used together to ensure that the most recently accessed
+      // or added item is always considered the "newest" in terms of access order.
+      // This is crucial for maintaining the correct order of elements in the cache,
+      // which directly impacts which item is considered the least recently used (LRU) and
+      // thus eligible for eviction when the cache reaches its capacity.
+      this.delete(key)
+      this.cache.set(key, value)
+    }
+
+    return value
+  }
+
+  set(key: string, value: string): this {
+    if (this.capacity === 0) {
+      return this
+    }
+
+    if (this.cache.has(key)) {
+      this.cache.delete(key)
+    } else if (this.cache.size >= this.capacity) {
+      // To evict the least recently used (LRU) item, we retrieve the first key in the Map.
+      // This is possible because the Map object in JavaScript maintains the insertion order of the keys.
+      // Therefore, the first key represents the oldest entry, which is the least recently used item in our cache.
+      // We use Map.prototype.keys().next().value to obtain this oldest key and then delete it from the cache.
+      const oldestKey = this.cache.keys().next().value
+      if (oldestKey) {
+        this.delete(oldestKey)
+      }
+    }
+
+    this.cache.set(key, value)
+    return this
+  }
+}

--- a/packages/core/src/cache/lru-in-memory-assignment-cache.ts
+++ b/packages/core/src/cache/lru-in-memory-assignment-cache.ts
@@ -1,0 +1,18 @@
+import { AbstractAssignmentCache } from './abstract-assignment-cache'
+import { LRUCache } from './lru-cache'
+
+/**
+ * A cache that uses the LRU algorithm to evict the least recently used items.
+ *
+ * It is used to limit the size of the cache.
+ *
+ * The primary use case is for server-side SDKs, where the cache is shared across
+ * multiple users. In this case, the cache size should be set to the maximum number
+ * of users that can be active at the same time.
+ * @param {number} maxSize - Maximum cache size
+ */
+export class LRUInMemoryAssignmentCache extends AbstractAssignmentCache<LRUCache> {
+  constructor(maxSize: number) {
+    super(new LRUCache(maxSize))
+  }
+}

--- a/packages/core/src/configuration/configuration.ts
+++ b/packages/core/src/configuration/configuration.ts
@@ -34,7 +34,7 @@ export type PrecomputedConfigurationResponse = {
   data: {
     attributes: {
       /** When configuration was generated. */
-      createdAt: number
+      createdAt: string
       flags: Record<string, PrecomputedFlag>
     }
   }

--- a/packages/core/test/cache/lru-cache.spec.ts
+++ b/packages/core/test/cache/lru-cache.spec.ts
@@ -1,0 +1,79 @@
+import { LRUCache } from '../../src/cache/lru-cache'
+
+describe('LRUCache', () => {
+  let cache: LRUCache
+
+  beforeEach(() => {
+    cache = new LRUCache(2)
+  })
+
+  it('should insert and retrieve a value', () => {
+    cache.set('a', 'apple')
+    expect(cache.get('a')).toBe('apple')
+  })
+
+  it('should return undefined for missing values', () => {
+    expect(cache.get('missing')).toBeFalsy()
+  })
+
+  it('should overwrite existing values', () => {
+    cache.set('a', 'apple')
+    cache.set('a', 'avocado')
+    expect(cache.get('a')).toBe('avocado')
+  })
+
+  it('should evict least recently used item', () => {
+    cache.set('a', 'apple')
+    cache.set('b', 'banana')
+    cache.set('c', 'cherry')
+    expect(cache.get('a')).toBeFalsy()
+    expect(cache.get('b')).toBe('banana')
+    expect(cache.get('c')).toBe('cherry')
+  })
+
+  it('should move recently used item to the end of the cache', () => {
+    cache.set('a', 'apple')
+    cache.set('b', 'banana')
+    cache.get('a') // Access 'a' to make it recently used
+    cache.set('c', 'cherry')
+    expect(cache.get('a')).toBe('apple')
+    expect(cache.get('b')).toBeFalsy()
+    expect(cache.get('c')).toBe('cherry')
+  })
+
+  it('should check if a key exists', () => {
+    cache.set('a', 'apple')
+    expect(cache.has('a')).toBeTruthy()
+    expect(cache.has('b')).toBeFalsy()
+  })
+
+  it('should handle the cache capacity of zero', () => {
+    const zeroCache = new LRUCache(0)
+    zeroCache.set('a', 'apple')
+    expect(zeroCache.get('a')).toBeFalsy()
+  })
+
+  it('should handle the cache capacity of one', () => {
+    const oneCache = new LRUCache(1)
+    oneCache.set('a', 'apple')
+    expect(oneCache.get('a')).toBe('apple')
+    oneCache.set('b', 'banana')
+    expect(oneCache.get('a')).toBeFalsy()
+    expect(oneCache.get('b')).toBe('banana')
+  })
+
+  /**
+   This test case might be an overkill but in case Map() changes,
+   or we want to ditch it completely this will remind us that insertion
+   order is crucial for this cache to work properly
+   **/
+  it('should preserve insertion order when inserting on capacity limit', () => {
+    cache.set('a', 'apple')
+    cache.set('b', 'banana')
+    cache.set('c', 'cherry')
+
+    const keys = Array.from(cache.keys())
+    expect(keys[0]).toBe('b')
+    expect(keys[1]).toBe('c')
+  })
+})

--- a/packages/core/test/tsconfig.json
+++ b/packages/core/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.cjs.json",
   "compilerOptions": {
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "rootDir": "."
   },
-  "include": ["./src/**/*.spec.ts", "./src/**/*.test.ts"],
+  "include": ["./src/**/*.ts", "./test/**/*.ts"],
   "exclude": []
 }


### PR DESCRIPTION
## Motivation

Deduplicates exposure logging in the node-server SDK using caching via an in-memory LRU cache.

## Changes

Functionality largely taken from Eppo's `node-server-sdk` and `js-sdk-common`