### PR TITLE
fix: allow for experimentation to clear exposure cache

### DIFF
--- a/packages/browser/src/cache/chrome-storage-assignment-cache.ts
+++ b/packages/browser/src/cache/chrome-storage-assignment-cache.ts
@@ -33,4 +33,8 @@ export default class ChromeStorageAssignmentCache implements BulkReadAssignmentC
     const entries = await this.storage.entries()
     return Object.entries(entries).map(([key, value]) => [key, value] as [string, string])
   }
+
+  async clear(): Promise<void> {
+    await this.storage.clear()
+  }
 }

--- a/packages/browser/src/cache/chrome-storage-async-map.ts
+++ b/packages/browser/src/cache/chrome-storage-async-map.ts
@@ -21,4 +21,8 @@ export default class ChromeStorageAsyncMap<T> implements AsyncMap<string, T> {
   async set(key: string, value: T) {
     await this.storage.set({ [key]: value })
   }
+
+  async clear() {
+    await this.storage.clear()
+  }
 }

--- a/packages/browser/src/cache/hybrid-assignment-cache.ts
+++ b/packages/browser/src/cache/hybrid-assignment-cache.ts
@@ -37,4 +37,8 @@ export default class HybridAssignmentCache implements AssignmentCache {
   has(key: AssignmentCacheEntry): boolean {
     return this.servingStore.has(key)
   }
+
+  async clear(): Promise<void> {
+    await Promise.all([this.servingStore.clear(), this.persistentStore.clear()])
+  }
 }

--- a/packages/browser/src/cache/simple-assignment-cache.ts
+++ b/packages/browser/src/cache/simple-assignment-cache.ts
@@ -38,4 +38,8 @@ export default class SimpleAssignmentCache implements BulkWriteAssignmentCache, 
   getEntries(): Promise<[string, string][]> {
     return Promise.resolve(Array.from(this.cache.entries()))
   }
+
+  clear(): void {
+    this.cache.clear()
+  }
 }

--- a/packages/core/src/cache/abstract-assignment-cache.ts
+++ b/packages/core/src/cache/abstract-assignment-cache.ts
@@ -37,6 +37,8 @@ export interface AssignmentCache {
   set(key: AssignmentCacheEntry): void
 
   has(key: AssignmentCacheEntry): boolean
+
+  clear(): Promise<void> | void
 }
 
 export abstract class AbstractAssignmentCache<T extends Map<string, string>> implements AssignmentCache {
@@ -70,5 +72,10 @@ export abstract class AbstractAssignmentCache<T extends Map<string, string>> imp
    */
   entries(): IterableIterator<[string, string]> {
     return this.delegate.entries()
+  }
+
+  /** Clears all entries from the cache. */
+  clear(): void {
+    this.delegate.clear()
   }
 }

--- a/packages/node-server/src/provider.ts
+++ b/packages/node-server/src/provider.ts
@@ -60,8 +60,14 @@ export class DatadogNodeServerProvider implements Provider {
    * Used by dd-source-js
    */
   setConfiguration(configuration: UniversalFlagConfigurationV1) {
+    const prevCreatedAt = this.configuration?.createdAt
     if (this.configuration && this.configuration !== configuration) {
       this.events.emit(ProviderEvents.ConfigurationChanged)
+      const newCreatedAt = configuration?.createdAt
+      if (prevCreatedAt !== newCreatedAt) {
+        this.exposureCache?.clear()
+      }
+      this.configuration = configuration
       return
     }
     this.configuration = configuration


### PR DESCRIPTION
## Motivation

This solves a specific situation. Consider a scenario where the start time of an experiment is moved up by several days.  In that scenario, existing exposures would be cached and wouldn't be included in the experiment analysis. By clearing the cache when the UFC createdAt changes, we can give experimentation a utility function that allows them to generate a new UFC with a different `createdAt` when they need to. This essentially allows us to have a server-side way of clearing the exposure cache by generating a new UFC.

## Changes

Experiment cache is now cleared when config changes.