### PR TITLE
v0.1.0-preview.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ---
 
+## v0.1.0-preview.16
+
+**Internal Changes:**
+
+- feat: initialization timeout in node OF provider ([#79](https://github.com/DataDog/openfeature-js-client/pull/79)) [NODE-SERVER]
+- fix: run prettier and add it to CI ([#80](https://github.com/DataDog/openfeature-js-client/pull/80)) [BROWSER] [NODE-SERVER]
+
 ## v0.1.0-preview.15
 
 - Internal updates

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "npmClient": "yarn",
-  "version": "0.1.0-preview.15"
+  "version": "0.1.0-preview.16"
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-browser",
-  "version": "0.1.0-preview.15",
+  "version": "0.1.0-preview.16",
   "description": "Browser-specific bindings for OpenFeature (wraps @datadog/openfeature-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@datadog/browser-core": "^6.19.0",
-    "@datadog/flagging-core": "0.1.0-preview.15",
+    "@datadog/flagging-core": "0.1.0-preview.16",
     "@types/chrome": "^0.1.18"
   },
   "peerDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/flagging-core",
-  "version": "0.1.0-preview.15",
+  "version": "0.1.0-preview.16",
   "description": "Runtime-agnostic flag-evaluation logic for Datadog Flagging",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-node-server",
-  "version": "0.1.0-preview.15",
+  "version": "0.1.0-preview.16",
   "description": "React Native bindings for OpenFeature (wraps @datadog/flagging-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",
@@ -36,7 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@datadog/flagging-core": "0.1.0-preview.15",
+    "@datadog/flagging-core": "0.1.0-preview.16",
     "@openfeature/server-sdk": "~1.18.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -557,7 +557,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/flagging-core@npm:0.1.0-preview.15, @datadog/flagging-core@workspace:packages/core":
+"@datadog/flagging-core@npm:0.1.0-preview.16, @datadog/flagging-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@datadog/flagging-core@workspace:packages/core"
   dependencies:
@@ -581,7 +581,7 @@ __metadata:
   resolution: "@datadog/openfeature-browser@workspace:packages/browser"
   dependencies:
     "@datadog/browser-core": "npm:^6.19.0"
-    "@datadog/flagging-core": "npm:0.1.0-preview.15"
+    "@datadog/flagging-core": "npm:0.1.0-preview.16"
     "@openfeature/core": "npm:^1.8.1"
     "@openfeature/web-sdk": "npm:^1.5.0"
     "@types/chrome": "npm:^0.1.18"
@@ -627,7 +627,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/openfeature-node-server@workspace:packages/node-server"
   dependencies:
-    "@datadog/flagging-core": "npm:0.1.0-preview.15"
+    "@datadog/flagging-core": "npm:0.1.0-preview.16"
     "@openfeature/core": "npm:^1.9.0"
     "@openfeature/server-sdk": "npm:~1.18.0"
     "@types/jest": "npm:^30.0.0"


### PR DESCRIPTION
## v0.1.0-preview.16

**Internal Changes:**

- feat: initialization timeout in node OF provider ([#79](https://github.com/DataDog/openfeature-js-client/pull/79)) [NODE-SERVER]
- fix: run prettier and add it to CI ([#80](https://github.com/DataDog/openfeature-js-client/pull/80)) [BROWSER] [NODE-SERVER]