### PR TITLE
remove preview tag from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,18 @@
 # Datadog OpenFeature JavaScript Clients
 
-This repository hosts Browser and React Native clients for Datadog's OpenFeature implementation.
+This repository hosts Browser and React Native clients, as well as the
+NodeJS flag evaluator, for Datadog's OpenFeature implementation.
 
-**Note: This project is currently in development; expect breaking API changes.**
+**Note: This project is currently in Preview; expect breaking API changes.**
+
+## Documentation
+
+Please see the full documentation site: [Getting Started with Feature Flags](https://docs.datadoghq.com/getting_started/feature_flags/)
 
 ## Installation
 
-### For Customers (Recommended)
-
-**We do not recommend pinning to an exact _preview_ version:**
-
-Use the `preview` tag for the latest preview version:
-
 ```bash
-npm install @datadog/openfeature-browser@preview
-```
-
-This will install the latest _preview_ version.
-
-### Specific Version
-
-You can also install a specific _preview_ version:
-
-```bash
-npm install @datadog/openfeature-browser@0.1.0-preview.x
+npm install @datadog/openfeature-browser
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

* not using preview tag anymore
* no link to official DD docs

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

* general release instructions
* links to DD docs

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Updated Documentation
- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/openfeature-js-client/blob/main/CONTRIBUTING.md -->
