### PR TITLE
drop support for RUM custom actions exposure logging

### DIFF
--- a/packages/browser/src/domain/configuration.ts
+++ b/packages/browser/src/domain/configuration.ts
@@ -34,11 +34,6 @@ export interface FlaggingInitConfiguration extends InitConfiguration {
      * @deprecated Use enableExposureLogging instead
      */
     ddFlaggingTracking?: boolean
-    /**
-     * Whether to log exposures in RUM
-     * @deprecated Use enableExposureLogging instead. This legacy approach logs exposures as RUM actions.
-     */
-    ddExposureLogging?: boolean
   }
 
   /**

--- a/packages/browser/src/openfeature/exposures.ts
+++ b/packages/browser/src/openfeature/exposures.ts
@@ -19,26 +19,6 @@ export function createRumTrackingHook(rum: DDRum): Hook {
 }
 
 /**
- * Create hook for RUM exposure logging
- * @deprecated
- */
-export function createRumExposureHook(rum: DDRum): Hook {
-  return {
-    after: (hookContext: HookContext, details: EvaluationDetails<FlagValue>) => {
-      rum.addAction('__dd_exposure', {
-        timestamp: dateNow(),
-        flag_key: details.flagKey,
-        allocation_key: (details.flagMetadata?.allocationKey as string) ?? '',
-        exposure_key: `${details.flagKey}-${details.flagMetadata?.allocationKey}`,
-        subject_key: hookContext.context.targetingKey,
-        subject_attributes: hookContext.context,
-        variant_key: details.variant,
-      })
-    },
-  }
-}
-
-/**
  * Create hook for exposure logging.
  */
 export function createExposureLoggingHook(configuration: FlaggingConfiguration, exposureCache: AssignmentCache): Hook {

--- a/packages/browser/src/openfeature/provider.ts
+++ b/packages/browser/src/openfeature/provider.ts
@@ -23,7 +23,7 @@ import {
   validateAndBuildFlaggingConfiguration,
 } from '../domain/configuration'
 import { evaluate } from '../evaluation'
-import { createExposureLoggingHook, createRumExposureHook, createRumTrackingHook } from './exposures'
+import { createExposureLoggingHook, createRumTrackingHook } from './exposures'
 
 /**
  * @deprecated Use FlaggingInitConfiguration instead
@@ -56,11 +56,6 @@ export class DatadogProvider implements Provider {
     // Add RUM flag tracking hook (DEPRECATED)
     if (options.rum?.ddFlaggingTracking) {
       this.hooks.push(createRumTrackingHook(options.rum.sdk))
-    }
-
-    // Add RUM exposure logging hook (DEPRECATED)
-    if (options.rum?.ddExposureLogging) {
-      this.hooks.push(createRumExposureHook(options.rum.sdk))
     }
 
     // Add proper exposure logging hook (creates batch internally)

--- a/packages/browser/src/openfeature/rumIntegration.ts
+++ b/packages/browser/src/openfeature/rumIntegration.ts
@@ -1,6 +1,4 @@
 export interface DDRum {
   // biome-ignore lint/suspicious/noExplicitAny: DD RUM interface
   addFeatureFlagEvaluation: (flagKey: string, value: any) => void
-  // biome-ignore lint/suspicious/noExplicitAny: DD RUM interface
-  addAction: (actionName: string, params: Record<string, any>) => void
 }


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

This feature is deprecated and it's time to remove it because we have native EVP evaluations and exposures in this SDK.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

Fully drop support for RUM-based custom actions based exposures.

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Updated Documentation
- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/openfeature-js-client/blob/main/CONTRIBUTING.md -->
