### PR TITLE
chore: relase v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@
 
 ---
 
+## v0.3.0
+
+**Internal Changes:**
+
+- chore:add dependabot ([#97](https://github.com/DataDog/openfeature-js-client/pull/97))
+- [EX-1234] Add flagevaluation tracking event emission. ([#94](https://github.com/DataDog/openfeature-js-client/pull/94)) [BROWSER] [NODE-SERVER]
+- drop support for RUM custom actions exposure logging ([#95](https://github.com/DataDog/openfeature-js-client/pull/95)) [BROWSER]
+- chore: validate license name, script python requirements ([#93](https://github.com/DataDog/openfeature-js-client/pull/93))
+- docs: update contributing with guide to install dd-license-attribution ([#96](https://github.com/DataDog/openfeature-js-client/pull/96))
+- Update copyright notice to 2025-present ([#92](https://github.com/DataDog/openfeature-js-client/pull/92)) [BROWSER] [NODE-SERVER]
+- remove preview tag from docs ([#91](https://github.com/DataDog/openfeature-js-client/pull/91))
+- chore: validate version consistency in CI ([#90](https://github.com/DataDog/openfeature-js-client/pull/90))
+- chore(deps-dev): bump glob from 11.0.3 to 11.1.0 ([#88](https://github.com/DataDog/openfeature-js-client/pull/88))
+- chore: CI check to validate licenses are up to date ([#89](https://github.com/DataDog/openfeature-js-client/pull/89))
+- chore: upgrade to latest version of openfeature sdk ([#87](https://github.com/DataDog/openfeature-js-client/pull/87)) [NODE-SERVER]
+
 ## v0.2.0
 
 **Internal Changes:**

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "npmClient": "yarn",
-  "version": "0.2.0"
+  "version": "0.3.0"
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-browser",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Browser-specific bindings for OpenFeature (wraps @datadog/openfeature-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@datadog/browser-core": "^6.19.0",
-    "@datadog/flagging-core": "0.2.0",
+    "@datadog/flagging-core": "0.3.0",
     "@types/chrome": "^0.1.18"
   },
   "peerDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/flagging-core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Runtime-agnostic flag-evaluation logic for Datadog Flagging",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-node-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "React Native bindings for OpenFeature (wraps @datadog/flagging-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",
@@ -36,7 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@datadog/flagging-core": "0.2.0",
+    "@datadog/flagging-core": "0.3.0",
     "@openfeature/server-sdk": "~1.20.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -557,7 +557,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/flagging-core@npm:0.2.0, @datadog/flagging-core@workspace:packages/core":
+"@datadog/flagging-core@npm:0.3.0, @datadog/flagging-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@datadog/flagging-core@workspace:packages/core"
   dependencies:
@@ -581,7 +581,7 @@ __metadata:
   resolution: "@datadog/openfeature-browser@workspace:packages/browser"
   dependencies:
     "@datadog/browser-core": "npm:^6.19.0"
-    "@datadog/flagging-core": "npm:0.2.0"
+    "@datadog/flagging-core": "npm:0.3.0"
     "@openfeature/core": "npm:^1.8.1"
     "@openfeature/web-sdk": "npm:^1.5.0"
     "@types/chrome": "npm:^0.1.18"
@@ -627,7 +627,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/openfeature-node-server@workspace:packages/node-server"
   dependencies:
-    "@datadog/flagging-core": "npm:0.2.0"
+    "@datadog/flagging-core": "npm:0.3.0"
     "@openfeature/core": "npm:^1.9.0"
     "@openfeature/server-sdk": "npm:~1.20.0"
     "@types/jest": "npm:^30.0.0"


### PR DESCRIPTION
## v0.3.0

**Internal Changes:**

- chore:add dependabot ([#97](https://github.com/DataDog/openfeature-js-client/pull/97))
- [EX-1234] Add flagevaluation tracking event emission. ([#94](https://github.com/DataDog/openfeature-js-client/pull/94)) [BROWSER] [NODE-SERVER]
- drop support for RUM custom actions exposure logging ([#95](https://github.com/DataDog/openfeature-js-client/pull/95)) [BROWSER]
- chore: validate license name, script python requirements ([#93](https://github.com/DataDog/openfeature-js-client/pull/93))
- docs: update contributing with guide to install dd-license-attribution ([#96](https://github.com/DataDog/openfeature-js-client/pull/96))
- Update copyright notice to 2025-present ([#92](https://github.com/DataDog/openfeature-js-client/pull/92)) [BROWSER] [NODE-SERVER]
- remove preview tag from docs ([#91](https://github.com/DataDog/openfeature-js-client/pull/91))
- chore: validate version consistency in CI ([#90](https://github.com/DataDog/openfeature-js-client/pull/90))
- chore(deps-dev): bump glob from 11.0.3 to 11.1.0 ([#88](https://github.com/DataDog/openfeature-js-client/pull/88))
- chore: CI check to validate licenses are up to date ([#89](https://github.com/DataDog/openfeature-js-client/pull/89))
- chore: upgrade to latest version of openfeature sdk ([#87](https://github.com/DataDog/openfeature-js-client/pull/87)) [NODE-SERVER]

[EX-1234]: https://datadoghq.atlassian.net/browse/EX-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ