### PR TITLE
chore: don't have dependabot group package updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,8 +1,7 @@
 # Dependabot configuration for openfeature-js-client monorepo
 # Documentation: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
-# Strategy: Dependabot handles both security and version updates with grouped PRs
-# to reduce noise while maintaining security awareness.
+# Strategy: Each dependency update creates a separate PR for granular control and review.
 
 version: 2
 updates:
@@ -14,7 +13,7 @@ updates:
       day: 'monday'
       time: '09:00'
       timezone: 'America/New_York'
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - 'dependencies'
       - 'npm'
@@ -25,24 +24,6 @@ updates:
       include: 'scope'
     reviewers:
       - 'CODEOWNERS'
-    groups:
-      # Group all non-major updates together
-      development-dependencies:
-        dependency-type: 'development'
-        update-types:
-          - 'minor'
-          - 'patch'
-      production-dependencies:
-        dependency-type: 'production'
-        update-types:
-          - 'minor'
-          - 'patch'
-    ignore:
-      # Let major updates come through individually for review
-      - dependency-name: '*'
-        update-types: ['version-update:semver-major']
-      # Add specific ignores here with issue tracking, e.g.:
-      # - dependency-name: 'package-name'  # Issue: PROJ-1234
 
   # Browser package
   - package-ecosystem: 'npm'
@@ -52,7 +33,7 @@ updates:
       day: 'monday'
       time: '09:00'
       timezone: 'America/New_York'
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - 'dependencies'
       - 'npm'
@@ -63,16 +44,6 @@ updates:
       include: 'scope'
     reviewers:
       - 'CODEOWNERS'
-    groups:
-      browser-dependencies:
-        patterns:
-          - '*'
-        update-types:
-          - 'minor'
-          - 'patch'
-    ignore:
-      - dependency-name: '*'
-        update-types: ['version-update:semver-major']
 
   # Core package
   - package-ecosystem: 'npm'
@@ -82,7 +53,7 @@ updates:
       day: 'monday'
       time: '09:00'
       timezone: 'America/New_York'
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - 'dependencies'
       - 'npm'
@@ -93,16 +64,6 @@ updates:
       include: 'scope'
     reviewers:
       - 'CODEOWNERS'
-    groups:
-      core-dependencies:
-        patterns:
-          - '*'
-        update-types:
-          - 'minor'
-          - 'patch'
-    ignore:
-      - dependency-name: '*'
-        update-types: ['version-update:semver-major']
 
   # Node server package
   - package-ecosystem: 'npm'
@@ -112,7 +73,7 @@ updates:
       day: 'monday'
       time: '09:00'
       timezone: 'America/New_York'
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - 'dependencies'
       - 'npm'
@@ -123,16 +84,6 @@ updates:
       include: 'scope'
     reviewers:
       - 'CODEOWNERS'
-    groups:
-      node-server-dependencies:
-        patterns:
-          - '*'
-        update-types:
-          - 'minor'
-          - 'patch'
-    ignore:
-      - dependency-name: '*'
-        update-types: ['version-update:semver-major']
 
   # Test app
   - package-ecosystem: 'npm'
@@ -142,7 +93,7 @@ updates:
       day: 'monday'
       time: '09:00'
       timezone: 'America/New_York'
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 10
     labels:
       - 'dependencies'
       - 'npm'
@@ -151,13 +102,6 @@ updates:
       prefix: '👷 chore(test-app)'
       prefix-development: '👷 chore(test-app)'
       include: 'scope'
-    groups:
-      test-app-dependencies:
-        patterns:
-          - '*'
-        update-types:
-          - 'minor'
-          - 'patch'
 
   # GitHub Actions dependencies
   - package-ecosystem: 'github-actions'
@@ -167,14 +111,10 @@ updates:
       day: 'monday'
       time: '09:00'
       timezone: 'America/New_York'
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - 'dependencies'
       - 'github-actions'
     commit-message:
       prefix: '👷 ci'
       include: 'scope'
-    groups:
-      github-actions:
-        patterns:
-          - '*'


### PR DESCRIPTION
## Motivation

upgrading several (16) packages at once and there are breakages. Upgrading one by one will make it easier to isolate incompatibilities.
