### PR TITLE
fix(browser): prevent exposure cache from being cleared on page load

### DIFF
--- a/packages/browser/src/openfeature/provider.ts
+++ b/packages/browser/src/openfeature/provider.ts
@@ -155,7 +155,7 @@ export class DatadogProvider implements Provider {
     const prevCreatedAt = this.flagsConfiguration?.precomputed?.response.data.attributes.createdAt
     const flagsConfiguration = await this.configuration.fetchFlagsConfiguration(context)
     const newCreatedAt = flagsConfiguration.precomputed?.response.data.attributes.createdAt
-    if (prevCreatedAt !== newCreatedAt) {
+    if (prevCreatedAt !== undefined && prevCreatedAt !== newCreatedAt) {
       await this.exposureCache?.clear()
     }
     return flagsConfiguration

--- a/packages/browser/test/openfeature/exposures.spec.ts
+++ b/packages/browser/test/openfeature/exposures.spec.ts
@@ -577,6 +577,66 @@ describe('Exposures End-to-End', () => {
       expect(getExposuresCalls()).toHaveLength(2)
     })
 
+    it('should not clear exposure cache on initial page load', async () => {
+      // This test simulates a page reload where the cache already has entries from a previous session
+      const response = {
+        ...precomputedServerResponse,
+        data: {
+          ...precomputedServerResponse.data,
+          attributes: {
+            ...precomputedServerResponse.data.attributes,
+            createdAt: 1731939805123,
+          },
+        },
+      }
+
+      fetchMock.mockImplementation((url: string) => {
+        if (url.includes('exposures')) {
+          return Promise.resolve({ ok: true, status: 200 })
+        }
+        if (url.includes('precompute-assignments')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(response),
+          })
+        }
+        return Promise.resolve({ ok: true })
+      })
+
+      // Set context before provider initialization
+      await OpenFeature.setContext({
+        targetingKey: 'test-user-123',
+        customAttribute: 'test-value',
+      })
+
+      // Initialize provider and evaluate flag to populate cache
+      const provider1 = new DatadogProvider(providerConfig)
+      await OpenFeature.setProviderAndWait(provider1)
+      const client1 = OpenFeature.getClient()
+
+      client1.getStringValue('string-flag', 'default')
+      triggerBatch()
+
+      // Verify first exposure was logged
+      expect(getExposuresCalls()).toHaveLength(1)
+
+      // Simulate page reload: clear providers but keep localStorage
+      await OpenFeature.clearProviders()
+      fetchMock.mockClear()
+
+      // Re-initialize provider (simulating page reload)
+      const provider2 = new DatadogProvider(providerConfig)
+      await OpenFeature.setProviderAndWait(provider2)
+      const client2 = OpenFeature.getClient()
+
+      // Evaluate same flag - should NOT log because cache persisted from localStorage
+      client2.getStringValue('string-flag', 'default')
+      triggerBatch()
+
+      // Should have no new exposure calls (cache was loaded from localStorage)
+      expect(getExposuresCalls()).toHaveLength(0)
+    })
+
     it('should not clear exposure cache when configuration createdAt stays the same', async () => {
       // Create two responses with same createdAt
       const firstResponse = {


### PR DESCRIPTION
## Motivation

On initial page load, `prevCreatedAt` was undefined which caused the condition `prevCreatedAt !== newCreatedAt` to always be true, clearing the exposure cache loaded from localStorage.

👉 That means that the exposure cache was effectively not working since it was always starting empty.

<img width="2493" height="1318" alt="Screenshot 2026-01-09 at 1 44 15 PM" src="https://github.com/user-attachments/assets/f86856a7-dc88-48b8-8209-dec9e2b44317" />
<img width="2493" height="1318" alt="Screenshot 2026-01-09 at 1 44 37 PM" src="https://github.com/user-attachments/assets/fb10e23b-c27a-4b05-a8bf-edb96e95a011" />

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

Now we skip the cache clear when `prevCreatedAt` is undefined (first load), only clearing when the config actually changes.

## Testing

Made a small test app

<img width="1603" height="1318" alt="Screenshot 2026-01-09 at 2 39 34 PM" src="https://github.com/user-attachments/assets/b27c4b41-fa17-436c-84e5-837ec1730478" />

First visit had a `flagevaluation` and an `exposure`

<img width="1603" height="1318" alt="Screenshot 2026-01-09 at 2 40 31 PM" src="https://github.com/user-attachments/assets/ce33b964-f965-4ee3-bd7b-254d496e85cc" />

✔️  Reloading the page only a `flagevaluation` is sent