### PR TITLE
fix(core): include empty string targeting keys in flag evaluation events

### DIFF
--- a/packages/core/src/configuration/flagEvaluationEvent.ts
+++ b/packages/core/src/configuration/flagEvaluationEvent.ts
@@ -27,7 +27,9 @@ export function createFlagEvaluationEvent(data: FlagEvaluationAggregationData, t
     timestamp,
   }
 
-  event.targeting_key = data.targetingKey ?? ''
+  if (data.targetingKey != null) {
+    event.targeting_key = data.targetingKey
+  }
 
   if (data.error) {
     event.error = { message: data.error }

--- a/packages/core/test/configuration/flagEvaluationEvent.spec.ts
+++ b/packages/core/test/configuration/flagEvaluationEvent.spec.ts
@@ -34,7 +34,7 @@ describe('createFlagEvaluationEvent', () => {
     expect(event).toHaveProperty('targeting_key')
   })
 
-  it('should convert undefined targeting_key to empty string', () => {
+  it('should not include targeting_key when it is undefined', () => {
     const event = createFlagEvaluationEvent(
       {
         flagKey: 'test-flag',
@@ -47,25 +47,7 @@ describe('createFlagEvaluationEvent', () => {
       2000
     )
 
-    expect(event.targeting_key).toBe('')
-    expect(event).toHaveProperty('targeting_key')
-  })
-
-  it('should convert null targeting_key to empty string', () => {
-    const event = createFlagEvaluationEvent(
-      {
-        flagKey: 'test-flag',
-        targetingKey: null as any,
-        count: 1,
-        firstEvaluation: 1000,
-        lastEvaluation: 1000,
-        runtimeDefaultUsed: false,
-      },
-      2000
-    )
-
-    expect(event.targeting_key).toBe('')
-    expect(event).toHaveProperty('targeting_key')
+    expect(event).not.toHaveProperty('targeting_key')
   })
 
   it('should include all required fields', () => {


### PR DESCRIPTION
## Motivation

The truthiness check for `targetingKey` in flag evaluation events was incorrectly excluding empty strings, which are valid targeting keys. This meant that evaluations with empty string targeting keys would omit the `targeting_key` field entirely from the event payload.

## Changes
 use `if (data.targetingKey != null)` instead of `if (data.targetingKey)`

## Test instructions

Run the test suite for the new test file:
```bash
cd packages/core && yarn test flagEvaluationEvent.spec
```

All 7 tests should pass, specifically verifying that:
- `targeting_key` is included when it's an empty string
- `targeting_key` is not included when it's undefined

## Checklist

- [ ] Updated Documentation
- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.