### PR TITLE
bug: allow empty string as valid targeting key in evaluation (FFL-1730)

### DIFF
--- a/packages/node-server/src/configuration/evaluation.ts
+++ b/packages/node-server/src/configuration/evaluation.ts
@@ -27,7 +27,7 @@ export function evaluate<T extends FlagValueType>(
   }
 
   const { targetingKey: subjectKey, ...remainingContext } = context
-  if (!subjectKey) {
+  if (subjectKey == null) {
     return {
       value: defaultValue,
       reason: 'ERROR',

--- a/packages/node-server/test/data/flags-v1.json
+++ b/packages/node-server/test/data/flags-v1.json
@@ -2891,6 +2891,34 @@
               "doLog": true
             }
           ]
+        },
+        "empty-targeting-key-flag": {
+          "key": "empty-targeting-key-flag",
+          "enabled": true,
+          "variationType": "STRING",
+          "variations": {
+            "on": {
+              "key": "on",
+              "value": "on-value"
+            },
+            "off": {
+              "key": "off",
+              "value": "off-value"
+            }
+          },
+          "allocations": [
+            {
+              "key": "default-allocation",
+              "rules": [],
+              "splits": [
+                {
+                  "variationKey": "on",
+                  "shards": []
+                }
+              ],
+              "doLog": true
+            }
+          ]
         }
       }
     }

--- a/packages/node-server/test/data/tests/test-case-of-7-empty-targeting-key.json
+++ b/packages/node-server/test/data/tests/test-case-of-7-empty-targeting-key.json
@@ -1,0 +1,12 @@
+[
+  {
+    "flag": "empty-targeting-key-flag",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "",
+    "attributes": {},
+    "result": {
+      "value": "on-value"
+    }
+  }
+]


### PR DESCRIPTION
## Motivation

Per OpenFeature specification OF.7, an empty string is a valid targeting key. However, the current evaluation logic uses a truthiness check `(!subjectKey)` which incorrectly rejects empty strings as `TARGETING_KEY_MISSING`.

This causes flag evaluations to fail and return the default value when a user provides an empty string targeting key, even though the flag configuration would otherwise match.

## Changes

* Changed if (!subjectKey) to if (subjectKey == null) to allow empty strings while still rejecting undefined/null

## Testing

All existing tests pass, plus the new test case validates:
- Flag: `empty-targeting-key-flag`
- Targeting key: "" (empty string)
- Expected result: "on-value" (not default)