### PR TITLE
Revert "drop support for RUM custom actions exposure logging (#95)"

### DIFF
--- a/packages/browser/src/domain/configuration.ts
+++ b/packages/browser/src/domain/configuration.ts
@@ -35,6 +35,11 @@ export interface FlaggingInitConfiguration extends InitConfiguration {
      * @deprecated Use enableExposureLogging instead
      */
     ddFlaggingTracking?: boolean
+    /**
+     * Whether to log exposures in RUM
+     * @deprecated Use enableExposureLogging instead. This legacy approach logs exposures as RUM actions.
+     */
+    ddExposureLogging?: boolean
   }
 
   /**

--- a/packages/browser/src/openfeature/exposures.ts
+++ b/packages/browser/src/openfeature/exposures.ts
@@ -19,6 +19,26 @@ export function createRumTrackingHook(rum: DDRum): Hook {
 }
 
 /**
+ * Create hook for RUM exposure logging
+ * @deprecated
+ */
+export function createRumExposureHook(rum: DDRum): Hook {
+  return {
+    after: (hookContext: HookContext, details: EvaluationDetails<FlagValue>) => {
+      rum.addAction('__dd_exposure', {
+        timestamp: dateNow(),
+        flag_key: details.flagKey,
+        allocation_key: (details.flagMetadata?.allocationKey as string) ?? '',
+        exposure_key: `${details.flagKey}-${details.flagMetadata?.allocationKey}`,
+        subject_key: hookContext.context.targetingKey,
+        subject_attributes: hookContext.context,
+        variant_key: details.variant,
+      })
+    },
+  }
+}
+
+/**
  * Create hook for exposure logging.
  */
 export function createExposureLoggingHook(configuration: FlaggingConfiguration, exposureCache: AssignmentCache): Hook {

--- a/packages/browser/src/openfeature/provider.ts
+++ b/packages/browser/src/openfeature/provider.ts
@@ -23,7 +23,7 @@ import {
   validateAndBuildFlaggingConfiguration,
 } from '../domain/configuration'
 import { evaluate } from '../evaluation'
-import { createExposureLoggingHook, createRumTrackingHook } from './exposures'
+import { createExposureLoggingHook, createRumExposureHook, createRumTrackingHook } from './exposures'
 import { createFlagEvaluationTrackingHook } from './flagEvaluations'
 
 /**
@@ -57,6 +57,11 @@ export class DatadogProvider implements Provider {
     // Add RUM flag tracking hook (DEPRECATED)
     if (options.rum?.ddFlaggingTracking) {
       this.hooks.push(createRumTrackingHook(options.rum.sdk))
+    }
+
+    // Add RUM exposure logging hook (DEPRECATED)
+    if (options.rum?.ddExposureLogging) {
+      this.hooks.push(createRumExposureHook(options.rum.sdk))
     }
 
     // Add flag evaluation tracking hook

--- a/packages/browser/src/openfeature/rumIntegration.ts
+++ b/packages/browser/src/openfeature/rumIntegration.ts
@@ -1,4 +1,6 @@
 export interface DDRum {
   // biome-ignore lint/suspicious/noExplicitAny: DD RUM interface
   addFeatureFlagEvaluation: (flagKey: string, value: any) => void
+  // biome-ignore lint/suspicious/noExplicitAny: DD RUM interface
+  addAction: (actionName: string, params: Record<string, any>) => void
 }


### PR DESCRIPTION
## Motivation

The previous removal of RUM custom actions exposure logging (#95) has blocked releases. The UI side is not yet ready to
fully migrate away from RUM custom actions, so we need to temporarily restore this functionality to enable double-writing
to both systems.

## Changes

Reverts commit 6c66315 to restore:
- `ddExposureLogging` configuration option for RUM-based exposure logging
- `createRumExposureHook` function that sends exposures via `rum.addAction('__dd_exposure', ...)`
- `addAction` method on the `DDRum` interface

This allows consumers to enable both:
- `ddExposureLogging` - legacy RUM custom actions (restored)
- `enableExposureLogging` - new EVP track intake

## Next Steps

Once the UI is ready to consume exposures from the new EVP track, we will permanently drop RUM custom actions support.