### PR TITLE
Default enableExposureLogging to true

### DIFF
--- a/packages/browser/src/openfeature/provider.ts
+++ b/packages/browser/src/openfeature/provider.ts
@@ -66,7 +66,8 @@ export class DatadogProvider implements Provider {
     }
 
     // Add proper exposure logging hook (creates batch internally)
-    if (options.enableExposureLogging && this.configuration) {
+    const isExposureLoggingEnabled = options.enableExposureLogging ?? true
+    if (isExposureLoggingEnabled && this.configuration) {
       this.exposureCache = assignmentCacheFactory({
         chromeStorage: chromeStorageIfAvailable(),
         storageKeySuffix: 'dd-of-browser',

--- a/packages/browser/test/openfeature/provider.spec.ts
+++ b/packages/browser/test/openfeature/provider.spec.ts
@@ -47,6 +47,68 @@ describe('DatadogProvider', () => {
     })
   })
 
+  describe('hooks configuration', () => {
+    it('should add exposure logging hook by default when enableExposureLogging is not specified', () => {
+      const providerWithDefaults = new DatadogProvider({
+        clientToken: 'xxx',
+        applicationId: 'xxx',
+        env: 'test',
+        site: INTAKE_SITE_STAGING,
+        // enableExposureLogging not specified - should default to true
+      })
+      // Should have 2 hooks: flag evaluation tracking (default true) + exposure logging (default true)
+      expect(providerWithDefaults.hooks).toHaveLength(2)
+    })
+
+    it('should not add exposure logging hook when enableExposureLogging is false', () => {
+      const providerWithoutExposures = new DatadogProvider({
+        clientToken: 'xxx',
+        applicationId: 'xxx',
+        env: 'test',
+        site: INTAKE_SITE_STAGING,
+        enableExposureLogging: false,
+      })
+      // Should have 1 hook: flag evaluation tracking only
+      expect(providerWithoutExposures.hooks).toHaveLength(1)
+    })
+
+    it('should add flag evaluation tracking hook by default when enableFlagEvaluationTracking is not specified', () => {
+      const providerWithDefaults = new DatadogProvider({
+        clientToken: 'xxx',
+        applicationId: 'xxx',
+        env: 'test',
+        site: INTAKE_SITE_STAGING,
+        // enableFlagEvaluationTracking not specified - should default to true
+      })
+      // Should have 2 hooks: flag evaluation tracking (default true) + exposure logging (default true)
+      expect(providerWithDefaults.hooks).toHaveLength(2)
+    })
+
+    it('should not add flag evaluation tracking hook when enableFlagEvaluationTracking is false', () => {
+      const providerWithoutEvalTracking = new DatadogProvider({
+        clientToken: 'xxx',
+        applicationId: 'xxx',
+        env: 'test',
+        site: INTAKE_SITE_STAGING,
+        enableFlagEvaluationTracking: false,
+      })
+      // Should have 1 hook: exposure logging only
+      expect(providerWithoutEvalTracking.hooks).toHaveLength(1)
+    })
+
+    it('should have no hooks when both tracking options are disabled', () => {
+      const providerWithNoHooks = new DatadogProvider({
+        clientToken: 'xxx',
+        applicationId: 'xxx',
+        env: 'test',
+        site: INTAKE_SITE_STAGING,
+        enableExposureLogging: false,
+        enableFlagEvaluationTracking: false,
+      })
+      expect(providerWithNoHooks.hooks).toHaveLength(0)
+    })
+  })
+
   describe('metadata', () => {
     beforeEach(() => {
       setupProvider()


### PR DESCRIPTION
## Motivation

While investigating a customer incident where exposures weren't being recorded, we discovered that `enableExposureLogging` defaults to `false` (or undefined), while `enableFlagEvaluationTracking` defaults to `true`. 

This inconsistency can lead to situations where flag evaluations are tracked but exposures are not.

## Changes

- Default `enableExposureLogging` to `true` in the browser SDK provider, matching the existing behavior of `enableFlagEvaluationTracking`
- Added unit tests to verify both defaults work correctly and can be explicitly disabled

## Decisions

- **Default to true**: EVP (Event Volume Pricing) tracks don't cost users additional money, so there's no billing concern with enabling this by default. Making it default to `true` provides a simpler UX that avoids surprises - if you set up an experiment, exposures will be tracked automatically.