### PR TITLE
v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ---
 
+## v0.3.2
+
+**Internal Changes:**
+
+- 👷 ci(deps): bump actions/setup-go from 6.0.0 to 6.1.0 ([#105](https://github.com/DataDog/openfeature-js-client/pull/105))
+- 👷 ci(deps): bump actions/setup-python from 6.0.0 to 6.1.0 ([#107](https://github.com/DataDog/openfeature-js-client/pull/107))
+- 👷 ci(deps): bump actions/setup-node from 4.4.0 to 6.1.0 ([#104](https://github.com/DataDog/openfeature-js-client/pull/104))
+- fix(core): resolve peer dependency errors for dd-trace-js users ([#150](https://github.com/DataDog/openfeature-js-client/pull/150)) [BROWSER] [NODE-SERVER]
+- bug: allow empty string as valid targeting key in evaluation (FFL-1730) ([#142](https://github.com/DataDog/openfeature-js-client/pull/142)) [NODE-SERVER]
+- fix(core): include empty string targeting keys in flag evaluation events ([#141](https://github.com/DataDog/openfeature-js-client/pull/141)) [BROWSER] [NODE-SERVER]
+
 ## v0.3.1
 
 **Internal Changes:**

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "npmClient": "yarn",
-  "version": "0.3.1"
+  "version": "0.3.2"
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-browser",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Browser-specific bindings for OpenFeature (wraps @datadog/openfeature-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@datadog/browser-core": "^6.19.0",
-    "@datadog/flagging-core": "0.3.1",
+    "@datadog/flagging-core": "0.3.2",
     "@types/chrome": "^0.1.18"
   },
   "peerDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/flagging-core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Runtime-agnostic flag-evaluation logic for Datadog Flagging",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-node-server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "React Native bindings for OpenFeature (wraps @datadog/flagging-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",
@@ -36,7 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@datadog/flagging-core": "0.3.1"
+    "@datadog/flagging-core": "0.3.2"
   },
   "peerDependencies": {
     "@openfeature/server-sdk": ">=1.15.0 <2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -557,7 +557,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/flagging-core@npm:0.3.1, @datadog/flagging-core@workspace:packages/core":
+"@datadog/flagging-core@npm:0.3.2, @datadog/flagging-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@datadog/flagging-core@workspace:packages/core"
   dependencies:
@@ -579,7 +579,7 @@ __metadata:
   resolution: "@datadog/openfeature-browser@workspace:packages/browser"
   dependencies:
     "@datadog/browser-core": "npm:^6.19.0"
-    "@datadog/flagging-core": "npm:0.3.1"
+    "@datadog/flagging-core": "npm:0.3.2"
     "@openfeature/core": "npm:^1.8.1"
     "@openfeature/web-sdk": "npm:^1.5.0"
     "@types/chrome": "npm:^0.1.18"
@@ -625,7 +625,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/openfeature-node-server@workspace:packages/node-server"
   dependencies:
-    "@datadog/flagging-core": "npm:0.3.1"
+    "@datadog/flagging-core": "npm:0.3.2"
     "@openfeature/core": "npm:1.3.0"
     "@openfeature/server-sdk": "npm:1.15.0"
     "@types/jest": "npm:^30.0.0"


### PR DESCRIPTION
## Motivation
Release v0.3.2 with bug fixes.

## Changes
- fix(core): resolve peer dependency errors for dd-trace-js users (#150)
- bug: allow empty string as valid targeting key in evaluation (#142)
- fix(core): include empty string targeting keys in flag evaluation events (#141)

## Decisions
Patch release as all changes are bug fixes with no new features or breaking changes.