### PR TITLE
Switch to independent (per-package) versioning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [main]
     tags:
-      - 'v*'
+      - 'core-v*'
+      - 'browser-v*'
+      - 'node-server-v*'
   pull_request:
   release:
     types: [created]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,21 +13,54 @@ jobs:
   validate-release:
     runs-on: ubuntu-latest
     environment: production
+    outputs:
+      package-dir: ${{ steps.parse-tag.outputs.package-dir }}
+      package-version: ${{ steps.parse-tag.outputs.package-version }}
+      package-prefix: ${{ steps.parse-tag.outputs.package-prefix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Validate release version
+      - name: Parse release tag
+        id: parse-tag
         run: |
-          # Check if the tag matches the version in lerna.json
-          RELEASE_VERSION="${{ github.event.release.tag_name }}"
-          LERNA_VERSION=$(node -p "require('./lerna.json').version")
+          TAG="${{ github.event.release.tag_name }}"
+          echo "Release tag: $TAG"
 
-          if [[ "v$LERNA_VERSION" != "$RELEASE_VERSION" ]]; then
-            echo "❌ Release tag $RELEASE_VERSION doesn't match lerna.json version v$LERNA_VERSION"
+          # Map tag prefix to package directory
+          if [[ "$TAG" =~ ^core-v(.+)$ ]]; then
+            PACKAGE_DIR="packages/core"
+            PACKAGE_VERSION="${BASH_REMATCH[1]}"
+            PACKAGE_PREFIX="core"
+          elif [[ "$TAG" =~ ^browser-v(.+)$ ]]; then
+            PACKAGE_DIR="packages/browser"
+            PACKAGE_VERSION="${BASH_REMATCH[1]}"
+            PACKAGE_PREFIX="browser"
+          elif [[ "$TAG" =~ ^node-server-v(.+)$ ]]; then
+            PACKAGE_DIR="packages/node-server"
+            PACKAGE_VERSION="${BASH_REMATCH[1]}"
+            PACKAGE_PREFIX="node-server"
+          else
+            echo "❌ Unrecognized tag format: $TAG"
+            echo "Expected: core-v{version}, browser-v{version}, or node-server-v{version}"
             exit 1
           fi
 
-          echo "✅ Release validation passed"
+          echo "package-dir=$PACKAGE_DIR" >> "$GITHUB_OUTPUT"
+          echo "package-version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "package-prefix=$PACKAGE_PREFIX" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release version
+        run: |
+          PACKAGE_DIR="${{ steps.parse-tag.outputs.package-dir }}"
+          EXPECTED_VERSION="${{ steps.parse-tag.outputs.package-version }}"
+          ACTUAL_VERSION=$(node -p "require('./$PACKAGE_DIR/package.json').version")
+
+          if [[ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]]; then
+            echo "❌ Release tag version $EXPECTED_VERSION doesn't match $PACKAGE_DIR/package.json version $ACTUAL_VERSION"
+            exit 1
+          fi
+
+          echo "✅ Release validation passed: $PACKAGE_DIR version $ACTUAL_VERSION"
 
   build-and-publish:
     runs-on: ubuntu-latest
@@ -74,8 +107,36 @@ jobs:
             echo "Using 'alpha' npm tag for prerelease $RELEASE_TAG"
           fi
 
-      - name: Publish core package
+      - name: Publish core package first (if needed)
+        if: needs.validate-release.outputs.package-prefix != 'core'
         run: |
+          PACKAGE_DIR="${{ needs.validate-release.outputs.package-dir }}"
+          PACKAGE_PREFIX="${{ needs.validate-release.outputs.package-prefix }}"
+
+          # Check if the tagged package depends on core
+          CORE_DEP_VERSION=$(node -p "
+            try {
+              const pkg = require('./$PACKAGE_DIR/package.json');
+              (pkg.dependencies || {})['@datadog/flagging-core'] || ''
+            } catch { '' }
+          ")
+
+          if [ -z "$CORE_DEP_VERSION" ]; then
+            echo "Package $PACKAGE_PREFIX does not depend on @datadog/flagging-core, skipping core publish"
+            exit 0
+          fi
+
+          CORE_ACTUAL_VERSION=$(node -p "require('./packages/core/package.json').version")
+
+          # Check if the required version of core is already on npm
+          echo "Checking if @datadog/flagging-core@$CORE_ACTUAL_VERSION is already on npm..."
+          if npm view "@datadog/flagging-core@$CORE_ACTUAL_VERSION" --json > /dev/null 2>&1; then
+            echo "✅ @datadog/flagging-core@$CORE_ACTUAL_VERSION is already available on npm"
+            exit 0
+          fi
+
+          echo "⚠️ @datadog/flagging-core@$CORE_ACTUAL_VERSION not found on npm."
+          echo "Publishing core first..."
           echo "//registry.npmjs.org/:_authToken=${{ secrets.ENV_NPM_TOKEN }}" > ~/.npmrc
           npm config set access public
           cd packages/core
@@ -83,30 +144,38 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.ENV_NPM_TOKEN }}
 
-      - name: Wait for core package to be available
+      - name: Wait for core package to be available (if needed)
+        if: needs.validate-release.outputs.package-prefix != 'core'
         run: |
-          # Get the version from lerna.json
-          VERSION=$(node -p "require('./lerna.json').version")
-          PACKAGE_NAME="@datadog/flagging-core"
+          PACKAGE_DIR="${{ needs.validate-release.outputs.package-dir }}"
 
-          echo "Waiting for $PACKAGE_NAME@$VERSION to be available on npm..."
-          echo "This may take a few minutes due to npm registry propagation..."
+          # Check if the tagged package depends on core
+          CORE_DEP_VERSION=$(node -p "
+            try {
+              const pkg = require('./$PACKAGE_DIR/package.json');
+              (pkg.dependencies || {})['@datadog/flagging-core'] || ''
+            } catch { '' }
+          ")
 
-          # Wait up to 5 minutes (300 seconds) with 10-second intervals
+          if [ -z "$CORE_DEP_VERSION" ]; then
+            echo "Package does not depend on @datadog/flagging-core, skipping wait"
+            exit 0
+          fi
+
+          CORE_ACTUAL_VERSION=$(node -p "require('./packages/core/package.json').version")
+
+          echo "Waiting for @datadog/flagging-core@$CORE_ACTUAL_VERSION to be available on npm..."
+
           for i in {1..30}; do
-            echo "Attempt $i/30: Checking if $PACKAGE_NAME@$VERSION is available..."
+            echo "Attempt $i/30: Checking if @datadog/flagging-core@$CORE_ACTUAL_VERSION is available..."
 
-            # Try to fetch the package info from npm
-            if npm view "$PACKAGE_NAME@$VERSION" --json > /dev/null 2>&1; then
-              echo "✅ $PACKAGE_NAME@$VERSION is now available on npm!"
-              echo "Package details:"
-              npm view "$PACKAGE_NAME@$VERSION" --json
-              break
+            if npm view "@datadog/flagging-core@$CORE_ACTUAL_VERSION" --json > /dev/null 2>&1; then
+              echo "✅ @datadog/flagging-core@$CORE_ACTUAL_VERSION is now available on npm!"
+              exit 0
             fi
 
             if [ $i -eq 30 ]; then
-              echo "❌ Timeout: $PACKAGE_NAME@$VERSION is still not available after 5 minutes"
-              echo "This might indicate an issue with the npm publish or registry propagation"
+              echo "❌ Timeout: @datadog/flagging-core@$CORE_ACTUAL_VERSION is still not available after 5 minutes"
               exit 1
             fi
 
@@ -114,20 +183,15 @@ jobs:
             sleep 10
           done
 
-      - name: Publish browser package
+      - name: Publish tagged package
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.ENV_NPM_TOKEN }}" > ~/.npmrc
-          npm config set access public
-          cd packages/browser
-          npm publish --tag ${{ steps.npm-tag.outputs.tag }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.ENV_NPM_TOKEN }}
+          PACKAGE_DIR="${{ needs.validate-release.outputs.package-dir }}"
+          PACKAGE_PREFIX="${{ needs.validate-release.outputs.package-prefix }}"
 
-      - name: Publish node-server package
-        run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.ENV_NPM_TOKEN }}" > ~/.npmrc
           npm config set access public
-          cd packages/node-server
+          cd "$PACKAGE_DIR"
+          echo "Publishing $(node -p "require('./package.json').name")..."
           npm publish --tag ${{ steps.npm-tag.outputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.ENV_NPM_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # openfeature-js-client
 
-Monorepo using **Lerna** with **fixed versioning** — all packages share the version in `lerna.json`.
+Monorepo using **Lerna** with **independent versioning** — each package has its own version in its `package.json`.
 
 ## Release
 
@@ -9,8 +9,19 @@ See [CONTRIBUTING.md](CONTRIBUTING.md#creating-a-release) for the full release p
 Key commands:
 
 ```bash
-# Non-interactive version bump (use this instead of interactive `yarn release`)
-yarn lerna version <VERSION> --exact --force-publish --yes
+# Interactive version bump (prompts per changed package)
+yarn release
+
+# Non-interactive version bump for a specific package
+yarn lerna version <VERSION> --exact --yes --scope=@datadog/openfeature-browser
+```
+
+### Tag naming convention
+
+```
+core-v{version}        → publishes @datadog/flagging-core
+browser-v{version}     → publishes @datadog/openfeature-browser
+node-server-v{version} → publishes @datadog/openfeature-node-server
 ```
 
 ## Packages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,9 @@ This is a monorepo managed with Lerna that contains multiple packages:
 
 - **`@datadog/flagging-core`** - Runtime-agnostic flag-evaluation logic
 - **`@datadog/openfeature-browser`** - Browser-specific bindings for OpenFeature
+- **`@datadog/openfeature-node-server`** - Node.js server bindings for OpenFeature
 
-The project uses **fixed versioning**, meaning all packages share the same version number and are released together. The version is managed centrally in `lerna.json`.
+The project uses **independent versioning**, meaning each package has its own version number in its `package.json` and can be released independently.
 
 ## Development Setup
 
@@ -92,7 +93,7 @@ All packages are published with the `latest` npm tag.
 
 1. **Switch to a feature branch:**
    ```bash
-   git checkout -b release/v1.2.3
+   git checkout -b release/browser-v1.2.0
    ```
 
 #### Step 2: Prepare Package Dependencies
@@ -105,29 +106,36 @@ All packages are published with the `latest` npm tag.
 
    This command:
    - Validates you're not on the `main` branch
-   - Runs `lerna version --exact --force-publish` to update the version
-   - Prompts for the new version number (applied to all packages)
-   - Creates version commits and tags
-   - Updates all package versions to match
-   - Pushes version tag to Github
+   - Runs `lerna version --exact` to update versions
+   - Prompts for a version bump for each changed package individually
+   - Creates version commits and per-package git tags
+   - Pushes version tags to Github
 
 #### Step 3: Publish via GitHub Release
 
 **Publishing is fully automated via GitHub workflows!**
 
+Each package uses its own tag naming convention:
+
+- `core-v{version}` → publishes `@datadog/flagging-core`
+- `browser-v{version}` → publishes `@datadog/openfeature-browser`
+- `node-server-v{version}` → publishes `@datadog/openfeature-node-server`
+
 1. **Create a GitHub Release:**
    - Go to the GitHub repository
    - Click "Releases" → "Create a new release"
-   - Set the tag to match your version (e.g., `v1.1.0`)
+   - Set the tag to match the package you want to publish (e.g., `browser-v1.2.0`)
    - Add release notes describing your changes or use the `Generate Release Notes` button
    - Click "Publish release"
+   - Repeat for each package that needs publishing
 
 2. **Automated Publishing Workflow:**
 
    The `release.yaml` workflow will automatically trigger and:
 
    **Validation Phase:**
-   - Checks that the GitHub release tag matches the version in `lerna.json`
+   - Parses the tag to determine which package to publish (e.g., `browser-v1.2.0` → `packages/browser`)
+   - Validates the tag version matches that package's `package.json` version
    - Fails fast if validation doesn't pass
 
    **Build and Publish Phase:**
@@ -135,14 +143,9 @@ All packages are published with the `latest` npm tag.
    - Builds all packages in release mode (`BUILD_MODE=release`)
    - Creates package tarballs with `yarn lerna run pack --stream`
 
-   **Publishing Sequence:**
-   1. **Publishes core package first** (`@datadog/flagging-core`)
-   2. **Waits for npm registry propagation**
-      - Polls npm registry for up to 5 minutes
-      - Ensures core package is available before proceeding
-      - Prevents dependency resolution issues
-   3. **Publishes browser package** (`@datadog/openfeature-browser`)
-   4. **Publishes node-server package** (`@datadog/openfeature-node-server`)
+   **Publishing:**
+   - If the tagged package depends on `@datadog/flagging-core` and core is not yet on npm at the required version, publishes core first and waits for registry propagation
+   - Publishes the tagged package to npm
 
 ### Package-Specific Build Commands
 
@@ -196,30 +199,29 @@ yarn pack
 
 ### Version Management
 
-Since this project uses **fixed versioning**:
+This project uses **independent versioning**:
 
-- All packages share the same version number (managed in `lerna.json`)
-- When running `yarn release`, Lerna will prompt for a single version update
-- All package versions are automatically synchronized
-- Peer dependencies are automatically updated to match the fixed version
-- A single version commit and tag is created for the entire project
+- Each package has its own version in its `package.json`
+- When running `yarn release`, Lerna prompts for a version bump per changed package
+- Internal dependencies (e.g. `@datadog/flagging-core`) are updated to match actual versions
+- Per-package git tags and version commits are created (e.g., `core-v1.1.0`, `browser-v1.2.0`)
+- Packages can be released independently — only the tagged package is published
 
 ### Automated Release Workflow Details
 
 The GitHub Actions workflow (`release.yaml`) includes several safety measures:
 
-1. **Version Consistency Check:**
-   - Compares GitHub release tag with `lerna.json` version
-   - Ensures tags and versions are synchronized
+1. **Tag Parsing and Validation:**
+   - Parses the per-package tag (e.g. `browser-v1.2.0` → `packages/browser`, version `1.2.0`)
+   - Validates the tag version matches the package's `package.json`
 
 2. **Dependency Coordination:**
-   - Core package is published first
-   - Waits for npm registry propagation (up to 5 minutes)
-   - Browser package gets updated core dependency automatically
+   - If the tagged package depends on `@datadog/flagging-core`, checks if the required version is on npm
+   - If not available, publishes core first and waits for registry propagation (up to 5 minutes)
 
 3. **Build Integrity:**
    - Uses `BUILD_MODE=release` for production builds
-   - Replaces build environment variables correctly
+   - Replaces build environment variables correctly per-package
    - Creates both npm packages and CDN bundles
 
 ### Testing Before Release
@@ -264,23 +266,21 @@ The GitHub Actions workflow (`release.yaml`) includes several safety measures:
    - Solution: Create a feature branch for releases
 
 2. **Version mismatch in GitHub workflow:**
-   - Error: "Release tag doesn't match lerna.json version"
-   - Solution: Ensure the GitHub release tag exactly matches `v{version}` format where `{version}` is from `lerna.json`
+   - Error: "Release tag version doesn't match package.json version"
+   - Solution: Ensure the GitHub release tag matches the format `{package}-v{version}` where `{version}` matches the package's `package.json` (e.g., `browser-v1.2.0`)
 
 3. **Build environment issues:**
    - Ensure `BUILD_MODE` and `SDK_SETUP` are set correctly
    - Check that all dependencies are installed
 
 4. **Version synchronization issues:**
-   - Run `yarn version` to update peer dependencies
-   - Check that all package versions match the version in `lerna.json`
+   - Run `yarn version` to update internal dependency versions
+   - Check that internal dependency versions in each package match the actual version in the dependency's `package.json`
 
 5. **GitHub workflow failures:**
    - Check the Actions tab for detailed error logs
-   - Ensure GitHub secrets are properly configured:
-     - `NPM_PUBLISH_TOKEN_FLAGGING_CORE` for core package
-     - `NPM_PUBLISH_TOKEN` for browser package
-   - Verify the release tag matches the version in `lerna.json`
+   - Ensure GitHub secrets are properly configured
+   - Verify the release tag uses the correct format: `core-v{version}`, `browser-v{version}`, or `node-server-v{version}`
 
 6. **npm registry propagation delays:**
    - The workflow waits up to 5 minutes for the core package to be available

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "npmClient": "yarn",
-  "version": "1.1.0"
+  "version": "independent"
 }

--- a/scripts/cli
+++ b/scripts/cli
@@ -33,9 +33,8 @@ cmd_lint () {
 
 cmd_release () {
   [[ `git branch --show-current` != "main" ]] || fail 'please do not release from `main` branch'
-  # We should publish all packages regardless of if there are changes in each.
-  # --force-publish will skip the `lerna changed` check for changed packages
-  yarn lerna version --exact --force-publish
+  # Independent versioning: Lerna will prompt for each changed package individually
+  yarn lerna version --exact
 }
 
 cmd_version () {

--- a/scripts/lib/buildEnv.js
+++ b/scripts/lib/buildEnv.js
@@ -77,13 +77,30 @@ function getSdkSetup() {
 }
 
 function getOpenFeatureVersion() {
-  // For fixed versioning, we'll use the version from lerna.json
+  // With independent versioning, find the nearest package.json by walking up
+  // from the current working directory (replace-build-env.js is called from each
+  // package's build script, so cwd is typically the package directory).
   try {
-    const lernaJsonPath = path.join(__dirname, '../../lerna.json')
-    const lernaJson = JSON.parse(readFileSync(lernaJsonPath, 'utf8'))
-    return lernaJson.version
+    let dir = process.cwd()
+    const root = path.join(__dirname, '../..')
+    while (dir.length >= root.length) {
+      const pkgPath = path.join(dir, 'package.json')
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+        if (pkg.version && pkg.name !== '@datadog/openfeature-client-monorepo') {
+          return pkg.version
+        }
+      } catch {
+        // no package.json at this level, keep walking up
+      }
+      const parent = path.dirname(dir)
+      if (parent === dir) break
+      dir = parent
+    }
+    console.warn('Could not find package version, using "0.1.0-alpha.2"')
+    return '0.1.0-alpha.2'
   } catch (error) {
-    console.warn('Could not read lerna.json version, using "0.1.0-alpha.2"', error)
+    console.warn('Could not read package version, using "0.1.0-alpha.2"', error)
     return '0.1.0-alpha.2'
   }
 }

--- a/scripts/lib/openfeatureVersion.js
+++ b/scripts/lib/openfeatureVersion.js
@@ -1,5 +1,37 @@
-const lernaJson = require('../../lerna.json')
+const fs = require('node:fs')
+const path = require('node:path')
+
+/**
+ * Read the version for a specific package directory, or return the highest
+ * version across all packages as a fallback.
+ */
+function getPackageVersion(packageDirName) {
+  if (packageDirName) {
+    const pkgPath = path.join(__dirname, '../../packages', packageDirName, 'package.json')
+    return JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version
+  }
+
+  // Fallback: return the highest version across all packages
+  const packagesDir = path.join(__dirname, '../../packages')
+  const versions = fs
+    .readdirSync(packagesDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => JSON.parse(fs.readFileSync(path.join(packagesDir, d.name, 'package.json'), 'utf8')).version)
+
+  versions.sort((a, b) => {
+    const pa = a.split('.').map(Number)
+    const pb = b.split('.').map(Number)
+    for (let i = 0; i < 3; i++) {
+      if (pa[i] !== pb[i]) return pb[i] - pa[i]
+    }
+    return 0
+  })
+
+  return versions[0]
+}
 
 module.exports = {
-  openfeatureVersion: lernaJson.version,
+  getPackageVersion,
+  // For backwards compatibility with changelog generation
+  openfeatureVersion: getPackageVersion(),
 }

--- a/scripts/release/generate-changelog/lib/addNewChangesToChangelog.js
+++ b/scripts/release/generate-changelog/lib/addNewChangesToChangelog.js
@@ -1,22 +1,58 @@
 const { readFile } = require('node:fs/promises')
 const fs = require('node:fs')
+const path = require('node:path')
 
 const emojiNameMap = require('emoji-name-map')
 
-const { openfeatureVersion } = require('../../../lib/openfeatureVersion')
+const { getPackageVersion } = require('../../../lib/openfeatureVersion')
 const { commandSync } = require('../../../lib/executionUtils')
 const { getAffectedPackages } = require('./getAffectedPackages')
 const { CHANGELOG_FILE, CONTRIBUTING_FILE, PUBLIC_EMOJI_PRIORITY, INTERNAL_EMOJI_PRIORITY } = require('./constants')
 
 const FIRST_EMOJI_REGEX = /\p{Extended_Pictographic}/u
 
+// Map directory names to package display names for changelog headers
+const DIR_TO_DISPLAY_NAME = {
+  core: '@datadog/flagging-core',
+  browser: '@datadog/openfeature-browser',
+  'node-server': '@datadog/openfeature-node-server',
+}
+
 /**
+ * Determines which packages have changed since the last release and generates
+ * changelog sections for each.
+ *
  * @param previousContent {string}
  * @returns {Promise<string>}
  */
 exports.addNewChangesToChangelog = async (previousContent) => {
   const emojisLegend = await getEmojisLegend()
-  const changeLists = getChangeLists()
+  const lastTagName = getLastReleaseTagName()
+
+  // Get all changed packages and generate per-package sections
+  const changedPackages = getChangedPackageDirectories(lastTagName)
+  const sections = []
+
+  for (const dirName of changedPackages) {
+    const displayName = DIR_TO_DISPLAY_NAME[dirName] || dirName
+    const version = getPackageVersion(dirName)
+    const changeLists = getChangeLists(lastTagName, dirName)
+
+    if (changeLists) {
+      sections.push(`## ${displayName} v${version}\n\n${changeLists}`)
+    }
+  }
+
+  // If no per-package changes detected, generate an unscoped section with all changes
+  if (sections.length === 0) {
+    const changeLists = getChangeLists(lastTagName, null)
+    if (changeLists) {
+      const highestVersion = getPackageVersion()
+      sections.push(`## v${highestVersion}\n\n${changeLists}`)
+    }
+  }
+
+  const newContent = sections.join('\n\n')
 
   return `\
 # Changelog
@@ -25,9 +61,7 @@ ${emojisLegend}
 
 ---
 
-## v${openfeatureVersion}
-
-${changeLists}
+${newContent}
 ${previousContent.slice(previousContent.indexOf('\n##'))}`
 }
 
@@ -54,8 +88,30 @@ async function getEmojisLegend() {
   return lines.join('\n')
 }
 
-function getChangeLists() {
-  const lastTagName = getLastReleaseTagName()
+/**
+ * Get the list of package directory names that have changes since the last tag.
+ */
+function getChangedPackageDirectories(lastTagName) {
+  const commits = commandSync`git log ${lastTagName}..HEAD --pretty=format:"%H %s"`.run().split('\n')
+  const packageDirs = new Set()
+
+  commits.forEach((commit) => {
+    const spaceIndex = commit.indexOf(' ')
+    const hash = commit.slice(0, spaceIndex)
+    const message = commit.slice(spaceIndex + 1)
+    if (isVersionMessage(message) || isStagingBumpMessage(message)) {
+      return
+    }
+    const affected = getAffectedPackages(hash)
+    for (const pkg of affected) {
+      packageDirs.add(pkg)
+    }
+  })
+
+  return Array.from(packageDirs).sort()
+}
+
+function getChangeLists(lastTagName, filterPackageDir) {
   const commits = commandSync`git log ${lastTagName}..HEAD --pretty=format:"%H %s"`.run().split('\n')
 
   const internalChanges = []
@@ -69,6 +125,14 @@ function getChangeLists() {
       return
     }
 
+    // If filtering by package, skip commits that don't affect it
+    if (filterPackageDir) {
+      const affected = getAffectedPackages(hash)
+      if (affected.length > 0 && !affected.includes(filterPackageDir)) {
+        return
+      }
+    }
+
     const change = formatChange(hash, message)
     const emoji = findFirstEmoji(change)
     if (PUBLIC_EMOJI_PRIORITY.includes(emoji)) {
@@ -78,17 +142,20 @@ function getChangeLists() {
     }
   })
 
-  return [
+  const result = [
     formatChangeList('Public Changes', publicChanges, PUBLIC_EMOJI_PRIORITY),
     formatChangeList('Internal Changes', internalChanges, INTERNAL_EMOJI_PRIORITY),
   ]
     .filter(Boolean)
     .join('\n\n')
+
+  return result || ''
 }
 
 function getLastReleaseTagName() {
   const changelog = fs.readFileSync(CHANGELOG_FILE, { encoding: 'utf-8' })
-  const match = changelog.match(/^## (v\d+\.\d+\.\d+.*)/m)
+  // Match both old-style "## v1.2.3" and new-style "## @datadog/package-name v1.2.3"
+  const match = changelog.match(/^## (?:@datadog\/\S+ )?(v\d+\.\d+\.\d+.*)/m)
   if (!match) {
     throw new Error('Could not find the last release version in the changelog')
   }

--- a/scripts/release/generate-changelog/lib/getAffectedPackages.js
+++ b/scripts/release/generate-changelog/lib/getAffectedPackages.js
@@ -5,6 +5,7 @@ const { commandSync } = require('../../../lib/executionUtils')
 const PACKAGE_NAME_TO_DIRECTORY = {
   '@datadog/openfeature-browser': 'browser',
   '@datadog/flagging-core': 'core',
+  '@datadog/openfeature-node-server': 'node-server',
 }
 
 const PACKAGES_REVERSE_DEPENDENCIES = (() => {

--- a/scripts/release/update-peer-dependency-versions.js
+++ b/scripts/release/update-peer-dependency-versions.js
@@ -2,41 +2,46 @@ const { runMain } = require('../lib/executionUtils')
 const { modifyFile } = require('../lib/filesUtils')
 const { command } = require('../lib/executionUtils')
 const { packagesDirectoryNames } = require('../lib/packagesDirectoryNames')
+const path = require('node:path')
+const fs = require('node:fs')
 
 const JSON_FILES = packagesDirectoryNames.map((packageName) => `./packages/${packageName}/package.json`)
 
-// This script updates the peer dependency versions between packages to match the new
-// versions during a release. Since we're using fixed versioning, we need to
-// read the version from lerna.json and update all packages to use that version.
+// This script updates the dependency versions between internal packages to match
+// the actual versions in each dependency's package.json. With independent versioning,
+// each package has its own version, so we read from each package.json directly.
 runMain(async () => {
-  // Read the version from lerna.json
-  const lernaJsonPath = require('node:path').join(__dirname, '../../lerna.json')
-  const lernaJson = JSON.parse(await require('node:fs').promises.readFile(lernaJsonPath, 'utf8'))
-  const version = lernaJson.version
+  // Build a map of internal package name -> actual version from each package.json
+  const internalVersions = {}
+  for (const dirName of packagesDirectoryNames) {
+    const pkgPath = path.join(__dirname, '../../packages', dirName, 'package.json')
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+    internalVersions[pkg.name] = pkg.version
+  }
 
-  console.log('Updating peer dependency versions to', version)
-  console.log('JSON_FILES', JSON_FILES)
-  const targetDeps = ['@datadog/openfeature-browser', '@datadog/flagging-core']
-  // Update peer dependencies
+  const targetDeps = Object.keys(internalVersions)
+  console.log('Internal package versions:', internalVersions)
+
+  // Update dependencies in each package to match actual versions
   for (const jsonFile of JSON_FILES) {
-    await modifyFile(jsonFile, (content) => updatePackageDependencies(content, version, targetDeps))
+    await modifyFile(jsonFile, (content) => updatePackageDependencies(content, internalVersions, targetDeps))
   }
 
   // update yarn.lock to match the updated JSON files
   command`yarn`.run()
 })
 
-function updatePackageDependencies(content, version, targetDeps) {
+function updatePackageDependencies(content, internalVersions, targetDeps) {
   const json = JSON.parse(content)
   Object.keys(json.peerDependencies || {})
     .filter((key) => targetDeps.includes(key))
     .forEach((key) => {
-      json.peerDependencies[key] = version
+      json.peerDependencies[key] = internalVersions[key]
     })
   Object.keys(json.dependencies || {})
     .filter((key) => targetDeps.includes(key))
     .forEach((key) => {
-      json.dependencies[key] = version
+      json.dependencies[key] = internalVersions[key]
     })
   return `${JSON.stringify(json, null, 2)}\n`
 }

--- a/scripts/versions-validate.sh
+++ b/scripts/versions-validate.sh
@@ -2,44 +2,77 @@
 
 set -euo pipefail
 
-package_json_files=$(find . -type f | grep package.json | grep -Ev '(\.git|node_modules|test-app)')
-
-echo "Validating package versions..."
-
-# Set reference version from lerna.json
-reference_version=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' lerna.json | grep -o '"[0-9][^"]*"' | tr -d '"')
-
-if [ -z "$reference_version" ]; then
-  echo "ERROR: Could not read version from lerna.json"
-  exit 1
-fi
-
-echo "Reference version: $reference_version (from lerna.json)"
-echo ""
+echo "Validating internal dependency versions..."
 
 mismatches=()
 
-for file in $package_json_files; do
-  # Extract version from package.json if it exists
-  version=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$file" | grep -o '"[0-9][^"]*"' | tr -d '"' || echo "")
-
-  # Skip files without a version field (like the root monorepo package.json)
-  if [ -z "$version" ]; then
+# For each package, check that its dependencies on internal packages
+# match the actual version in that dependency's package.json
+for package_dir in packages/*/; do
+  package_json="$package_dir/package.json"
+  if [ ! -f "$package_json" ]; then
     continue
   fi
 
-  # Compare against reference version
-  if [ "$version" != "$reference_version" ]; then
-    mismatches+=("$file has version $version (expected $reference_version)")
-  else
-    echo "✓ $file: $version"
-  fi
+  package_name=$(node -p "require('./$package_json').name")
+
+  # Check dependencies and peerDependencies for internal @datadog/ packages
+  for dep_type in dependencies peerDependencies; do
+    # Get internal deps (packages that exist in our monorepo)
+    internal_deps=$(node -p "
+      const pkg = require('./$package_json');
+      const deps = pkg['$dep_type'] || {};
+      const internal = Object.keys(deps).filter(d => d.startsWith('@datadog/'));
+      internal.join(',')
+    " 2>/dev/null || echo "")
+
+    if [ -z "$internal_deps" ]; then
+      continue
+    fi
+
+    IFS=',' read -ra dep_names <<< "$internal_deps"
+    for dep_name in "${dep_names[@]}"; do
+      if [ -z "$dep_name" ]; then
+        continue
+      fi
+
+      # Find the directory for this internal dep
+      dep_dir=$(node -p "
+        const fs = require('fs');
+        const dirs = fs.readdirSync('packages', { withFileTypes: true })
+          .filter(d => d.isDirectory())
+          .map(d => d.name);
+        const match = dirs.find(d => {
+          try {
+            return require('./packages/' + d + '/package.json').name === '$dep_name';
+          } catch { return false; }
+        });
+        match || ''
+      " 2>/dev/null || echo "")
+
+      if [ -z "$dep_dir" ]; then
+        # Not an internal monorepo package, skip
+        continue
+      fi
+
+      # Get the actual version from the dependency's package.json
+      actual_version=$(node -p "require('./packages/$dep_dir/package.json').version")
+      # Get the declared version in the consuming package
+      declared_version=$(node -p "require('./$package_json')['$dep_type']['$dep_name']")
+
+      if [ "$declared_version" != "$actual_version" ]; then
+        mismatches+=("$package_name $dep_type '$dep_name' is '$declared_version' but actual version is '$actual_version'")
+      else
+        echo "✓ $package_name $dep_type '$dep_name': $declared_version"
+      fi
+    done
+  done
 done
 
 # Report results
 if [ ${#mismatches[@]} -gt 0 ]; then
   echo ""
-  echo "ERROR: Version mismatches found:"
+  echo "ERROR: Internal dependency version mismatches found:"
   for mismatch in "${mismatches[@]}"; do
     echo "  - $mismatch"
   done
@@ -47,4 +80,4 @@ if [ ${#mismatches[@]} -gt 0 ]; then
 fi
 
 echo ""
-echo "All package versions match: $reference_version"
+echo "All internal dependency versions are consistent."


### PR DESCRIPTION
## Motivation

The monorepo currently uses Lerna fixed versioning — all 3 packages share one version and are always released together. This causes empty version bumps for `node-server` (consumed by `dd-trace-js`) when only browser changes ship, creating noise for downstream consumers.

This PR switches to independent versioning so each package has its own version and release lifecycle.

## Changes

Lerna is now configured in `"independent"` mode, with each package's `package.json` as its own version source of truth. All scripts that previously read a single version from `lerna.json` have been updated to read from the relevant `package.json` instead — the build system resolves the version by walking up from the package being built, the peer-dependency updater maps each internal dep to its actual version, and the CI validation script now checks that internal dependency versions are consistent across packages rather than enforcing a single global version.

The release workflow uses per-package git tags (`core-v{version}`, `browser-v{version}`, `node-server-v{version}`). When a GitHub Release is created with one of these tags, the workflow parses the tag to determine which package to publish and validates the version against that package's `package.json`. If the package depends on `@datadog/flagging-core` and that version isn't on npm yet, core is published first automatically. Changelog generation now produces per-package headers (e.g. `## @datadog/openfeature-browser v1.2.0`) and filters commits to the affected package.

From a developer perspective, `yarn release` now prompts for a version bump per changed package instead of applying one version to everything. Release branches and GitHub Releases are scoped to individual packages (e.g. `release/browser-v1.2.0`), and you create a separate GitHub Release for each package tag that needs publishing. Everything else — `yarn build`, `yarn test`, `yarn format:check` — works exactly the same.

## Decisions

- **Tag naming**: `core-v{version}`, `browser-v{version}`, `node-server-v{version}` — clear prefix-based convention
- **Release workflow**: Only the tagged package is published. Core is auto-published first if needed by a dependent package and not yet on npm.
- **Single CHANGELOG.md**: Kept, but each release section is scoped to the package name
- **Backwards-compatible changelog parsing**: `getLastReleaseTagName()` matches both old `## v1.2.3` and new `## @datadog/package-name v1.2.3` formats

## Test plan

- [x] `yarn build` succeeds (all 3 packages)
- [x] `yarn test` passes (368 tests: 25 core + 106 browser + 237 node-server)
- [x] `yarn format:check` passes
- [x] `yarn lint` passes
- [x] `bash scripts/versions-validate.sh` passes with packages at same version
- [ ] Manually verify release workflow tag parsing with a dry-run release