### PR TITLE
Remove registry-url from setup-node to fix OIDC publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,6 @@ jobs:
         with:
           node-version: '22.x'
           cache: 'yarn'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: yarn install --immutable


### PR DESCRIPTION
## Motivation

npm OIDC trusted publishing is failing with "Access token expired or revoked" even though no secrets exist in the repo.

**Root cause:** `setup-node` with `registry-url` writes an `.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}` and exports `NODE_AUTH_TOKEN` with a [placeholder value](https://github.com/actions/setup-node/blob/main/src/authutil.ts):

```typescript
// from actions/setup-node src/authutil.ts
core.exportVariable(
  'NODE_AUTH_TOKEN',
  process.env.NODE_AUTH_TOKEN || 'XXXXX-XXXXX-XXXXX-XXXXX'
);
```

npm uses this placeholder for token auth instead of falling through to OIDC.

Evidence from [failed run](https://github.com/DataDog/openfeature-js-client/actions/runs/22641624344/job/65619256143):
```
NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX   ← placeholder from setup-node
npm notice Access token expired or revoked. Please try logging in again.
```

## Changes

- Remove `registry-url` from `setup-node` in `release.yaml` (one line)
- npm defaults to `registry.npmjs.org`, so `registry-url` is unnecessary
- With Node 22 and `id-token: write`, npm handles OIDC natively without `.npmrc` configuration

## Local validation

**With `registry-url`** (setup-node's `.npmrc` + placeholder token) — npm silently uses the bogus token:
```
$ NODE_AUTH_TOKEN="XXXXX-XXXXX-XXXXX-XXXXX" NPM_CONFIG_USERCONFIG=<npmrc-with-authToken> \
    npm publish --dry-run 2>&1 | tail -3

npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access (dry-run)
+ @datadog/flagging-core@1.1.0
```

**Without `registry-url`** (no `.npmrc`, no token) — npm detects no auth and would request OIDC in CI:
```
$ NPM_CONFIG_USERCONFIG=<empty-npmrc> npm publish --dry-run 2>&1 | tail -3

npm warn This command requires you to be logged in to https://registry.npmjs.org/ (dry-run)
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access (dry-run)
+ @datadog/flagging-core@1.1.0
```

The "requires you to be logged in" path is where npm, in GitHub Actions with `id-token: write`, requests an OIDC token from the CI provider instead of using a stored credential.