### PR TITLE
Upgrade npm and add --provenance for OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           cache: 'yarn'
 
       - name: Install dependencies
@@ -77,7 +77,7 @@ jobs:
       - name: Publish core package
         run: |
           cd packages/core
-          npm publish --tag ${{ steps.npm-tag.outputs.tag }}
+          npm publish --provenance --tag ${{ steps.npm-tag.outputs.tag }}
 
       - name: Wait for core package to be available
         run: |
@@ -113,9 +113,9 @@ jobs:
       - name: Publish browser package
         run: |
           cd packages/browser
-          npm publish --tag ${{ steps.npm-tag.outputs.tag }}
+          npm publish --provenance --tag ${{ steps.npm-tag.outputs.tag }}
 
       - name: Publish node-server package
         run: |
           cd packages/node-server
-          npm publish --tag ${{ steps.npm-tag.outputs.tag }}
+          npm publish --provenance --tag ${{ steps.npm-tag.outputs.tag }}


### PR DESCRIPTION
## Motivation

OIDC publishing fails with `ENEEDAUTH` ([run](https://github.com/DataDog/openfeature-js-client/actions/runs/22642692839/job/65623713345)):
```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

Two issues:

1. **npm version too old**: Node 22 ships npm 10.9.4, but trusted publishing [requires npm >= 11.5.1](https://philna.sh/blog/2026/01/28/trusted-publishing-npm/). Confirmed in CI logs: `npm: 10.9.4`. Node 24 ships npm 11+ with built-in OIDC support. The [Confluence migration guide](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5629543176) also recommends `node-version: '24'`.
2. **Missing `--provenance` flag**: Triggers the OIDC token exchange with the registry.

## Changes

- Switch all workflows from Node 22 to Node 24 (`ci.yaml` + `release.yaml`)
- Remove the `npm install -g npm@latest` workaround (Node 24 has it built-in)
- Add `--provenance` to all 3 `npm publish` commands

## References

- [Confluence migration guide](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5629543176) — recommends `node-version: '24'`
- [npm trusted publishing docs](https://docs.npmjs.com/trusted-publishers/)
- ["Things you need to do for npm trusted publishing to work"](https://philna.sh/blog/2026/01/28/trusted-publishing-npm/) — confirms npm >= 11.5.1 and `--provenance` required