### PR TITLE
Publish all packages in single step, skip already-published versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,48 +74,41 @@ jobs:
             echo "Using 'alpha' npm tag for prerelease $RELEASE_TAG"
           fi
 
-      - name: Publish core package
+      - name: Publish all packages
         run: |
-          cd packages/core
-          npm publish --provenance --tag ${{ steps.npm-tag.outputs.tag }}
-
-      - name: Wait for core package to be available
-        run: |
-          # Get the version from lerna.json
           VERSION=$(node -p "require('./lerna.json').version")
-          PACKAGE_NAME="@datadog/flagging-core"
+          TAG="${{ steps.npm-tag.outputs.tag }}"
 
-          echo "Waiting for $PACKAGE_NAME@$VERSION to be available on npm..."
-          echo "This may take a few minutes due to npm registry propagation..."
+          publish_package() {
+            local pkg_dir=$1
+            local pkg_name=$(node -p "require('./$pkg_dir/package.json').name")
 
-          # Wait up to 5 minutes (300 seconds) with 10-second intervals
+            if npm view "$pkg_name@$VERSION" --json > /dev/null 2>&1; then
+              echo "⏭️  $pkg_name@$VERSION already published, skipping"
+              return 0
+            fi
+
+            echo "📦 Publishing $pkg_name@$VERSION..."
+            cd "$pkg_dir"
+            npm publish --provenance --tag "$TAG"
+            cd -
+          }
+
+          publish_package packages/core
+
+          # Wait for core to propagate before publishing dependents
+          echo "Waiting for @datadog/flagging-core@$VERSION to propagate..."
           for i in {1..30}; do
-            echo "Attempt $i/30: Checking if $PACKAGE_NAME@$VERSION is available..."
-
-            # Try to fetch the package info from npm
-            if npm view "$PACKAGE_NAME@$VERSION" --json > /dev/null 2>&1; then
-              echo "✅ $PACKAGE_NAME@$VERSION is now available on npm!"
-              echo "Package details:"
-              npm view "$PACKAGE_NAME@$VERSION" --json
+            if npm view "@datadog/flagging-core@$VERSION" --json > /dev/null 2>&1; then
+              echo "✅ @datadog/flagging-core@$VERSION is available"
               break
             fi
-
             if [ $i -eq 30 ]; then
-              echo "❌ Timeout: $PACKAGE_NAME@$VERSION is still not available after 5 minutes"
-              echo "This might indicate an issue with the npm publish or registry propagation"
+              echo "❌ Timeout waiting for core package"
               exit 1
             fi
-
-            echo "Package not yet available, waiting 10 seconds..."
             sleep 10
           done
 
-      - name: Publish browser package
-        run: |
-          cd packages/browser
-          npm publish --provenance --tag ${{ steps.npm-tag.outputs.tag }}
-
-      - name: Publish node-server package
-        run: |
-          cd packages/node-server
-          npm publish --provenance --tag ${{ steps.npm-tag.outputs.tag }}
+          publish_package packages/browser
+          publish_package packages/node-server


### PR DESCRIPTION
## Motivation

Two issues with the current release workflow:

1. **Can't re-run releases**: Core was published via OIDC successfully, but browser failed. Re-running the release fails with `You cannot publish over the previously published versions: 1.1.0` because core tries to publish again.

2. **OIDC token is single-use per publish**: Each `npm publish --provenance` call exchanges a short-lived OIDC token for a single-operation npm API token that [expires immediately after that publish](https://blog.makerx.com.au/catch-up-on-the-new-npm-trusted-publishing-feature/):

   > "npm exchanges this OIDC token for a short-lived npm API token that's used to complete the publish. This token exists only for the duration of that single operation."
   > — [MakerX: NPM Trusted Publishing](https://blog.makerx.com.au/catch-up-on-the-new-npm-trusted-publishing-feature/)

   When publish steps were separate, the first step (core) consumed the OIDC token. The browser step then tried to authenticate and failed with `ENEEDAUTH` because it couldn't obtain a fresh token. Publishing all packages in a **single shell step** keeps access to `ACTIONS_ID_TOKEN_REQUEST_URL`, allowing npm to request a fresh OIDC token for each publish call.

   Evidence from the [failed run](https://github.com/DataDog/openfeature-js-client/actions/runs/22644373740/job/65628494209):
   - Core: `✅ Signed provenance statement with source and build information from GitHub Actions`
   - Browser: `npm error code ENEEDAUTH` — same job, next step, token gone

## Changes

- Consolidate 3 separate publish steps + wait step into a single "Publish all packages" step
- Check `npm view` before each publish — skip if version already exists on npm
- Same core propagation wait logic, just inline

## How re-runs work now

On re-run, each `publish_package` call checks npm first:
```
⏭️  @datadog/flagging-core@1.1.0 already published, skipping
✅ @datadog/flagging-core@1.1.0 is available
📦 Publishing @datadog/openfeature-browser@1.1.0...
📦 Publishing @datadog/openfeature-node-server@1.1.0...
```

## References

- [npm OIDC tokens are single-use and short-lived](https://blog.makerx.com.au/catch-up-on-the-new-npm-trusted-publishing-feature/)
- [Monorepo: each package needs its own trusted publisher config](https://npmdigest.com/guides/npm-trusted-publishing)
- [GitHub Actions OIDC token is per-job, ~5min lifetime](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect)
- [npm Trusted Publishers docs](https://docs.npmjs.com/trusted-publishers/)