### PR TITLE
docs: fix misleading nested context example in browser README

### DIFF
--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -74,13 +74,16 @@ const config = await client.getObjectValue('feature-config', {})
 
 ### Using Evaluation Context
 
-Context must be set globally before flag evaluation and affects all subsequent evaluations:
+Context must be set globally before flag evaluation and affects all subsequent evaluations.
+
+**Note:** Context attributes must be flat key-value pairs. Nested objects are not supported for targeting rules. For full documentation, see the [Datadog Feature Flags JavaScript SDK docs](https://docs.datadoghq.com/feature_flags/client/javascript/?tab=npm).
 
 ```javascript
 // Set global context (async operation)
 await OpenFeature.setContext({
   targetingKey: 'user-123',
-  user: { id: 'user-123', email: 'user@example.com' },
+  user_id: 'user-123',
+  user_email: 'user@example.com',
 })
 
 // Now evaluate flags with the context


### PR DESCRIPTION
## Motivation

A user reported confusion because the README's evaluation context example showed nested objects (`user: { email: "..." }`), which implied nested attributes work for targeting rules. They don't — the Feature Flags backend only supports flat key-value pairs. See [Slack thread](https://datadoghq.slack.com/archives/C0000000000/p0000000000000000) for context.

## Changes

- Replaced the nested context example with flat key-value pairs (`user_id`, `user_email`)
- Added a note clarifying that nested objects are not supported for targeting rules
- Added a link to the [canonical Datadog docs](https://docs.datadoghq.com/feature_flags/client/javascript/?tab=npm) as the single source of truth

## Decisions

- Kept the README focused on quick-start usage rather than duplicating full documentation — the canonical docs link covers the rest