### PR TITLE
fix(node): mark open @openfeature/server-sdk as non-optional

### DIFF
--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -41,11 +41,6 @@
   "peerDependencies": {
     "@openfeature/server-sdk": ">=1.15.1"
   },
-  "peerDependenciesMeta": {
-    "@openfeature/server-sdk": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@openfeature/core": "1.9.2",
     "@openfeature/server-sdk": "1.20.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -752,9 +752,6 @@ __metadata:
     typescript: "npm:^5.9.3"
   peerDependencies:
     "@openfeature/server-sdk": ">=1.15.1"
-  peerDependenciesMeta:
-    "@openfeature/server-sdk":
-      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->
We have a non-type import here: https://github.com/DataDog/openfeature-js-client/blob/fae56cc9b1c8484b798458dbc124bf15c1120908/packages/node-server/src/provider.ts#L21

So the package must be present for our provider to work.

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Updated Documentation
- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/openfeature-js-client/blob/main/CONTRIBUTING.md -->
