### PR TITLE
chore: ignore dependabot major version upgrades

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,6 +24,10 @@ updates:
       prefix: "\U0001F477 chore(deps)"
       prefix-development: "\U0001F477 chore(deps-dev)"
       include: scope
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
     cooldown:
       default-days: 14
   - package-ecosystem: github-actions
@@ -43,5 +47,9 @@ updates:
     commit-message:
       prefix: "\U0001F477 ci(deps)"
       include: scope
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
     cooldown:
       default-days: 14


### PR DESCRIPTION
## Motivation

Major version upgrades require more manual scrutiny to make sure that nothing is broken.

## Changes

Ignoring dependabot major version upgrades