### PR TITLE
chore(browser): move @types/chrome from dependencies to devDependencies

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -45,8 +45,7 @@
   },
   "dependencies": {
     "@datadog/browser-core": "^6.19.0",
-    "@datadog/flagging-core": "1.1.0",
-    "@types/chrome": "^0.1.18"
+    "@datadog/flagging-core": "1.1.0"
   },
   "peerDependencies": {
     "@openfeature/core": "^1.9.2",
@@ -55,6 +54,7 @@
   "devDependencies": {
     "@openfeature/core": "^1.9.2",
     "@openfeature/web-sdk": "^1.5.0",
+    "@types/chrome": "^0.1.18",
     "@types/jest": "^30.0.0",
     "@types/node": "^18.0.0",
     "fake-indexeddb": "^6.2.5",


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->
Type-only dependencies should stay in dev dependencies.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Updated Documentation
- [X] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/openfeature-js-client/blob/main/CONTRIBUTING.md -->
