### PR TITLE
fix(browser): use public createFlagEvaluationEndpointBuilder from @datadog/browser-core

### DIFF
--- a/packages/browser/src/domain/configuration.ts
+++ b/packages/browser/src/domain/configuration.ts
@@ -1,6 +1,5 @@
 import type { Configuration, EndpointBuilder, InitConfiguration } from '@datadog/browser-core'
-import { display, validateAndBuildConfiguration } from '@datadog/browser-core'
-import { createEndpointBuilder, type TrackType } from '@datadog/browser-core/cjs/domain/configuration'
+import { createFlagEvaluationEndpointBuilder, display, validateAndBuildConfiguration } from '@datadog/browser-core'
 import type { FlagsConfiguration } from '@datadog/flagging-core'
 import type { EvaluationContext } from '@openfeature/web-sdk'
 import type { DDRum } from '../openfeature/rumIntegration'
@@ -82,7 +81,6 @@ export interface FlaggingConfiguration extends Configuration {
     options?: { signal?: AbortSignal }
   ) => Promise<FlagsConfiguration>
 
-  // [FlagEval] TODO: Remove this once we have a proper endpoint builder from browser core SDK.
   flagEvaluationEndpointBuilder: EndpointBuilder
 }
 
@@ -102,8 +100,7 @@ export function validateAndBuildFlaggingConfiguration(
   return {
     applicationId: initConfiguration.applicationId,
     flagEvaluationTrackingInterval: initConfiguration.flagEvaluationTrackingInterval ?? 10000,
-    // [FlagEval] TODO: Don't set this once we have a proper endpoint builder from browser core SDK
-    flagEvaluationEndpointBuilder: createEndpointBuilder(initConfiguration, 'flagevaluation' as TrackType),
+    flagEvaluationEndpointBuilder: createFlagEvaluationEndpointBuilder(initConfiguration),
     fetchFlagsConfiguration: createFlagsConfigurationFetcher(initConfiguration),
     ...baseConfiguration,
   }


### PR DESCRIPTION
## Problem

`packages/browser/src/domain/configuration.ts` imported `createEndpointBuilder` from a private deep subpath of `@datadog/browser-core`:

\`\`\`typescript
// biome-ignore lint/style/noRestrictedImports: createEndpointBuilder is not exported from the @datadog/browser-core root...
import { createEndpointBuilder, type TrackType } from '@datadog/browser-core/cjs/domain/configuration'
\`\`\`

This caused ESM/CJS bundler issues because the `/cjs/` subpath is an internal implementation detail, not part of the public API. The workaround also required an unsafe `as TrackType` cast to pass `'flagevaluation'` as the track type.

## Solution

Replaces the deep subpath import with the new `createFlagEvaluationEndpointBuilder` function from the public `@datadog/browser-core` root export:

\`\`\`typescript
import { createFlagEvaluationEndpointBuilder, display, validateAndBuildConfiguration } from '@datadog/browser-core'
\`\`\`

Usage becomes:

\`\`\`typescript
flagEvaluationEndpointBuilder: createFlagEvaluationEndpointBuilder(initConfiguration),
\`\`\`

This removes the `biome-ignore` suppression comment, the deep subpath import, and the `as TrackType` cast.

## Dependency

**Blocked on** DataDog/browser-sdk branch `typo/flag-evaluation-endpoint-builder` merging and a new version of `@datadog/browser-core` being released.

The currently installed version of `@datadog/browser-core` in `node_modules` does not yet export `createFlagEvaluationEndpointBuilder`, so TypeScript will report an error on this branch until the dependency ships. This is expected.

## Files changed

- `packages/browser/src/domain/configuration.ts`