### PR TITLE
fix(browser): bump @datadog/browser-core to ^6.33.0

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -44,7 +44,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@datadog/browser-core": "^6.19.0",
+    "@datadog/browser-core": "^6.33.0",
     "@datadog/flagging-core": "1.1.0"
   },
   "peerDependencies": {

--- a/packages/browser/src/domain/configuration.ts
+++ b/packages/browser/src/domain/configuration.ts
@@ -1,6 +1,5 @@
 import type { Configuration, EndpointBuilder, InitConfiguration } from '@datadog/browser-core'
 import { display, validateAndBuildConfiguration } from '@datadog/browser-core'
-import { createEndpointBuilder, type TrackType } from '@datadog/browser-core/cjs/domain/configuration'
 import type { FlagsConfiguration } from '@datadog/flagging-core'
 import type { EvaluationContext } from '@openfeature/web-sdk'
 import type { DDRum } from '../openfeature/rumIntegration'
@@ -82,7 +81,8 @@ export interface FlaggingConfiguration extends Configuration {
     options?: { signal?: AbortSignal }
   ) => Promise<FlagsConfiguration>
 
-  // [FlagEval] TODO: Remove this once we have a proper endpoint builder from browser core SDK.
+  // Inherited from Configuration via TransportConfiguration.
+  // Declared explicitly here to make the contract visible to consumers of FlaggingConfiguration.
   flagEvaluationEndpointBuilder: EndpointBuilder
 }
 
@@ -102,8 +102,6 @@ export function validateAndBuildFlaggingConfiguration(
   return {
     applicationId: initConfiguration.applicationId,
     flagEvaluationTrackingInterval: initConfiguration.flagEvaluationTrackingInterval ?? 10000,
-    // [FlagEval] TODO: Don't set this once we have a proper endpoint builder from browser core SDK
-    flagEvaluationEndpointBuilder: createEndpointBuilder(initConfiguration, 'flagevaluation' as TrackType),
     fetchFlagsConfiguration: createFlagsConfigurationFetcher(initConfiguration),
     ...baseConfiguration,
   }

--- a/packages/browser/src/openfeature/flagEvaluations.ts
+++ b/packages/browser/src/openfeature/flagEvaluations.ts
@@ -16,21 +16,13 @@ export function createFlagEvaluationTrackingHook(configuration: FlaggingConfigur
   const pageMayExitObservable = createPageMayExitObservable(configuration)
   const flagEvaluationBatch = createBatch({
     encoder: createIdentityEncoder(),
-    request: createHttpRequest(
-      [configuration.flagEvaluationEndpointBuilder],
-      configuration.batchBytesLimit,
-      (error: RawError) => {
-        addTelemetryDebug('Error reported to customer', { 'error.message': error.message })
-      }
-    ),
+    request: createHttpRequest([configuration.flagEvaluationEndpointBuilder], (error: RawError) => {
+      addTelemetryDebug('Error reported to customer', { 'error.message': error.message })
+    }),
     flushController: createFlushController({
-      messagesLimit: configuration.batchMessagesLimit,
-      bytesLimit: configuration.batchBytesLimit,
-      durationLimit: configuration.flushTimeout,
       pageMayExitObservable,
       sessionExpireObservable: new Observable(),
     }),
-    messageBytesLimit: configuration.messageBytesLimit,
   })
 
   const aggregator = new FlagEvaluationAggregator(

--- a/packages/browser/src/transport/startExposuresBatch.ts
+++ b/packages/browser/src/transport/startExposuresBatch.ts
@@ -15,15 +15,11 @@ export function startExposuresBatch(
 ) {
   const batch = createBatch({
     encoder: createIdentityEncoder(),
-    request: createHttpRequest([configuration.exposuresEndpointBuilder], configuration.batchBytesLimit, reportError),
+    request: createHttpRequest([configuration.exposuresEndpointBuilder], reportError),
     flushController: createFlushController({
-      messagesLimit: configuration.batchMessagesLimit,
-      bytesLimit: configuration.batchBytesLimit,
-      durationLimit: configuration.flushTimeout,
       pageMayExitObservable,
       sessionExpireObservable: new Observable(),
     }),
-    messageBytesLimit: configuration.messageBytesLimit,
   })
 
   return batch

--- a/packages/browser/test/openfeature/flagEvaluations.spec.ts
+++ b/packages/browser/test/openfeature/flagEvaluations.spec.ts
@@ -7,10 +7,6 @@ const mockConfiguration: FlaggingConfiguration = {
   applicationId: 'test-app-id',
   fetchFlagsConfiguration: jest.fn(),
   service: 'test-service',
-  batchBytesLimit: 64 * 1024,
-  batchMessagesLimit: 500,
-  messageBytesLimit: 256 * 1024,
-  flushTimeout: 30000 as any,
   exposuresEndpointBuilder: jest.fn() as any,
   flagEvaluationEndpointBuilder: jest.fn() as any,
   // Add required Configuration properties
@@ -18,8 +14,11 @@ const mockConfiguration: FlaggingConfiguration = {
   version: '1.0.0',
   sessionSampleRate: 100,
   telemetrySampleRate: 20,
-  replica: {} as any,
-  sendToExtensionPredicate: () => false,
+  // `as unknown as FlaggingConfiguration` is intentional: FlaggingConfiguration inherits many required
+  // fields from Configuration/TransportConfiguration (beforeSend, logsEndpointBuilder, sdkVersion, etc.)
+  // that createFlagEvaluationTrackingHook never reads. All @datadog/browser-core imports used by
+  // createFlagEvaluationTrackingHook are mocked at the module level below, so missing fields don't
+  // cause runtime failures.
 } as unknown as FlaggingConfiguration
 
 jest.mock('@datadog/browser-core', () => ({

--- a/packages/core/src/cache/lru-cache.ts
+++ b/packages/core/src/cache/lru-cache.ts
@@ -14,7 +14,7 @@
 export class LRUCache implements Map<string, string> {
   protected readonly cache = new Map<string, string>();
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   [Symbol.toStringTag]: string
 
   constructor(protected readonly capacity: number) {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,10 +652,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/browser-core@npm:^6.19.0":
-  version: 6.19.0
-  resolution: "@datadog/browser-core@npm:6.19.0"
-  checksum: 10c0/467a1ef719a6f4ead386009ad9410a39ecd4d97c0d20ac7fa7736a78d37940298bc54115c07837319af3d539010d7ee89b13606a6e7766f275a55036aa95b91b
+"@datadog/browser-core@npm:^6.33.0":
+  version: 6.33.0
+  resolution: "@datadog/browser-core@npm:6.33.0"
+  checksum: 10c0/137a504b755295eec3381445e76cd9e01c5edd92d8b308e1481a86407b8916f695e35771bd3f148f27754f01d75b808180fd9c08f4401066150527e27609309b
   languageName: node
   linkType: hard
 
@@ -689,7 +689,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/openfeature-browser@workspace:packages/browser"
   dependencies:
-    "@datadog/browser-core": "npm:^6.19.0"
+    "@datadog/browser-core": "npm:^6.33.0"
     "@datadog/flagging-core": "npm:1.1.0"
     "@openfeature/core": "npm:^1.9.2"
     "@openfeature/web-sdk": "npm:^1.5.0"


### PR DESCRIPTION
## Summary

- Bumps `@datadog/browser-core` from `^6.19.0` to `^6.33.0` (current latest)
- Removes dead `@datadog/browser-core/cjs/domain/configuration` deep-subpath import (was not in exports map; broke Vite/Rollup/webpack bundlers — root cause of #247). The dead assignment also causes TS2783 with the new browser-core types, so the two changes are inseparable.
- Adapts `flagEvaluations.ts` and `startExposuresBatch.ts` to the updated transport API (signature changes in 6.25.1)
- Removes stale mock fields from the `flagEvaluations` spec
- Replaces `@ts-ignore` with `@ts-expect-error` in `lru-cache.ts`

## Breaking API changes (browser-core ≥ 6.25.1)

`createHttpRequest(builders, reportError, bytesLimit?)` — `reportError` moved to 2nd argument.

`createFlushController` — `messagesLimit`, `bytesLimit`, `durationLimit` removed from options.

`createBatch` — `messageBytesLimit` removed.

## Verification

```
PASS: CJS configuration output is clean
PASS: ESM configuration output is clean
PASS: flagEvaluationEndpointBuilder works correctly
      URL: https://browser-intake-datadoghq.com/api/v2/flagevaluation
PASS: trackType is "flagevaluation"
=== Results: 4 passed, 0 failed ===
```

Closes #247.

## Test plan

- [ ] CI passes (lint, typecheck, unit tests)