### PR TITLE
fix(browser): remove dead @datadog/browser-core/cjs/ subpath import

### DIFF
--- a/packages/browser/src/domain/configuration.ts
+++ b/packages/browser/src/domain/configuration.ts
@@ -1,6 +1,5 @@
 import type { Configuration, EndpointBuilder, InitConfiguration } from '@datadog/browser-core'
 import { display, validateAndBuildConfiguration } from '@datadog/browser-core'
-import { createEndpointBuilder, type TrackType } from '@datadog/browser-core/cjs/domain/configuration'
 import type { FlagsConfiguration } from '@datadog/flagging-core'
 import type { EvaluationContext } from '@openfeature/web-sdk'
 import type { DDRum } from '../openfeature/rumIntegration'
@@ -82,7 +81,8 @@ export interface FlaggingConfiguration extends Configuration {
     options?: { signal?: AbortSignal }
   ) => Promise<FlagsConfiguration>
 
-  // [FlagEval] TODO: Remove this once we have a proper endpoint builder from browser core SDK.
+  // Inherited from Configuration via TransportConfiguration.
+  // Declared explicitly here to make the contract visible to consumers of FlaggingConfiguration.
   flagEvaluationEndpointBuilder: EndpointBuilder
 }
 
@@ -102,8 +102,6 @@ export function validateAndBuildFlaggingConfiguration(
   return {
     applicationId: initConfiguration.applicationId,
     flagEvaluationTrackingInterval: initConfiguration.flagEvaluationTrackingInterval ?? 10000,
-    // [FlagEval] TODO: Don't set this once we have a proper endpoint builder from browser core SDK
-    flagEvaluationEndpointBuilder: createEndpointBuilder(initConfiguration, 'flagevaluation' as TrackType),
     fetchFlagsConfiguration: createFlagsConfigurationFetcher(initConfiguration),
     ...baseConfiguration,
   }


### PR DESCRIPTION
## Summary

Removes a deep subpath import `@datadog/browser-core/cjs/domain/configuration` that was never in the package's exports map. TypeScript emits it verbatim into ESM output, causing bundler failures (Vite/Rollup/webpack) when strict subpath resolution is enabled — the root cause of the breakage reported in #247.

The `createEndpointBuilder` call it powered was always a dead assignment: the `...baseConfiguration` spread on the next line overwrites it. `validateAndBuildConfiguration` already returns `flagEvaluationEndpointBuilder` via `TransportConfiguration` (since browser-core 6.25.1).

**Stacks on:** #261 (browser-core bump to ^6.33.0 + transport API adaptation)

## Verification

```
PASS: CJS configuration output is clean
PASS: ESM configuration output is clean
PASS: flagEvaluationEndpointBuilder works correctly
      URL: https://browser-intake-datadoghq.com/api/v2/flagevaluation
PASS: trackType is "flagevaluation"
=== Results: 4 passed, 0 failed ===
```

## Test plan

- [ ] CI passes
- [ ] No `/cjs/` subpath imports remain in built output