### PR TITLE
fix: avoid MapIterator in declarations to support TypeScript < 5.6

### DIFF
--- a/packages/browser/src/cache/local-storage-assignment-shim.ts
+++ b/packages/browser/src/cache/local-storage-assignment-shim.ts
@@ -1,7 +1,7 @@
 // noinspection JSUnusedGlobalSymbols (methods are used by common repository)
 import { hasWindowLocalStorage } from './helpers'
 
-export class LocalStorageAssignmentShim implements Map<string, string> {
+export class LocalStorageAssignmentShim {
   private readonly localStorageKey: string
 
   public constructor(storageKeySuffix: string) {
@@ -28,25 +28,17 @@ export class LocalStorageAssignmentShim implements Map<string, string> {
     this.getCache().forEach(callbackfn, thisArg)
   }
 
-  size: number = this.getCache().size
-
-  entries() {
+  entries(): IterableIterator<[string, string]> {
     return this.getCache().entries()
   }
 
-  keys() {
+  keys(): IterableIterator<string> {
     return this.getCache().keys()
   }
 
-  values() {
+  values(): IterableIterator<string> {
     return this.getCache().values()
   }
-
-  [Symbol.iterator]() {
-    return this.getCache()[Symbol.iterator]()
-  }
-
-  [Symbol.toStringTag]: string = this.getCache()[Symbol.toStringTag]
 
   public has(key: string): boolean {
     return this.getCache().has(key)

--- a/packages/core/src/cache/abstract-assignment-cache.ts
+++ b/packages/core/src/cache/abstract-assignment-cache.ts
@@ -41,7 +41,22 @@ export interface AssignmentCache {
   clear(): Promise<void> | void
 }
 
-export abstract class AbstractAssignmentCache<T extends Map<string, string>> implements AssignmentCache {
+/**
+ * Minimal interface for the backing store used by {@link AbstractAssignmentCache}.
+ *
+ * Using a narrower constraint instead of `Map<string, string>` avoids emitting
+ * `MapIterator` (introduced in TypeScript 5.6) in declaration files, which would
+ * break consumers on TypeScript < 5.6.
+ */
+export interface CacheDelegate {
+  get(key: string): string | undefined
+  set(key: string, value: string): this
+  has(key: string): boolean
+  clear(): void
+  entries(): IterableIterator<[string, string]>
+}
+
+export abstract class AbstractAssignmentCache<T extends CacheDelegate> implements AssignmentCache {
   // key -> variation value hash
   protected constructor(protected readonly delegate: T) {}
 
@@ -70,7 +85,7 @@ export abstract class AbstractAssignmentCache<T extends Map<string, string>> imp
    * Returns an array with all {@link AssignmentCacheEntry} entries in the cache as an array of
    * {@link string}s.
    */
-  entries() {
+  entries(): IterableIterator<[string, string]> {
     return this.delegate.entries()
   }
 

--- a/packages/core/src/cache/lru-cache.ts
+++ b/packages/core/src/cache/lru-cache.ts
@@ -11,25 +11,12 @@
  * ```
  * Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
  */
-export class LRUCache implements Map<string, string> {
-  protected readonly cache = new Map<string, string>();
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-expect-error
-  [Symbol.toStringTag]: string
+export class LRUCache {
+  protected readonly cache = new Map<string, string>()
 
   constructor(protected readonly capacity: number) {}
 
-  [Symbol.iterator]() {
-    return this.cache[Symbol.iterator]()
-  }
-
-  forEach(callbackFn: (value: string, key: string, map: Map<string, string>) => void): void {
-    this.cache.forEach(callbackFn)
-  }
-
-  readonly size: number = this.cache.size
-
-  entries() {
+  entries(): IterableIterator<[string, string]> {
     return this.cache.entries()
   }
 
@@ -41,11 +28,11 @@ export class LRUCache implements Map<string, string> {
     return this.cache.delete(key)
   }
 
-  keys() {
+  keys(): IterableIterator<string> {
     return this.cache.keys()
   }
 
-  values() {
+  values(): IterableIterator<string> {
     return this.cache.values()
   }
 


### PR DESCRIPTION
## Problem

When `@datadog/flagging-core` is built with TypeScript 5.6+, the emitted `.d.ts` files use `MapIterator` as the return type for iterator methods on classes that `implements Map<string, string>`. `MapIterator` was introduced in TypeScript 5.6 and does not exist in older versions, so any consumer on TypeScript < 5.6 (with `skipLibCheck: false`) gets:

```
error TS2304: Cannot find name 'MapIterator'
```

This was a regression introduced when the package was rebuilt with TS 5.6+.

## Fix

- Introduce a `CacheDelegate` interface with `IterableIterator<>` return types as a narrower replacement for the `Map<string, string>` constraint on `AbstractAssignmentCache<T>`
- Remove `implements Map<string, string>` from `LRUCache` and `LocalStorageAssignmentShim`; add explicit `IterableIterator<>` return type annotations on iterator methods so the emitted declarations are pinned to `IterableIterator` regardless of which TypeScript version builds the package
- Remove `Symbol.iterator`, `Symbol.toStringTag`, `forEach`, and `size` from `LRUCache` as these were only required to satisfy the `Map` interface

## Testing

- All 26 existing tests pass
- Both `@datadog/flagging-core` and `@datadog/openfeature-browser` build cleanly
- Confirmed no `MapIterator` references in any emitted `.d.ts` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)