### PR TITLE
Add standardized __dd_ prefixed keys to flagMetadata

### DIFF
--- a/packages/browser/src/evaluation.ts
+++ b/packages/browser/src/evaluation.ts
@@ -51,6 +51,10 @@ function evaluatePrecomputed<T extends FlagValueType>(
     value: flag.variationValue as FlagTypeToValue<T>,
     variant: flag.variationKey,
     flagMetadata: {
+      // Standardized keys
+      __dd_allocation_key: flag.allocationKey,
+      __dd_do_log: flag.doLog,
+      // Deprecated keys (for backwards compatibility)
       allocationKey: flag.allocationKey,
       variationType: flag.variationType,
       doLog: flag.doLog,

--- a/packages/browser/test/evaluation.spec.ts
+++ b/packages/browser/test/evaluation.spec.ts
@@ -33,6 +33,8 @@ describe('evaluate', () => {
       variant: 'variation-124',
       reason: 'TARGETING_MATCH',
       flagMetadata: {
+        __dd_allocation_key: 'allocation-124',
+        __dd_do_log: true,
         allocationKey: 'allocation-124',
         doLog: true,
         variationType: 'BOOLEAN',
@@ -47,6 +49,8 @@ describe('evaluate', () => {
       variant: 'variation-123',
       reason: 'TARGETING_MATCH',
       flagMetadata: {
+        __dd_allocation_key: 'allocation-123',
+        __dd_do_log: true,
         allocationKey: 'allocation-123',
         doLog: true,
         variationType: 'STRING',
@@ -61,6 +65,8 @@ describe('evaluate', () => {
       variant: 'variation-127',
       reason: 'TARGETING_MATCH',
       flagMetadata: {
+        __dd_allocation_key: 'allocation-127',
+        __dd_do_log: true,
         allocationKey: 'allocation-127',
         doLog: true,
         variationType: 'OBJECT',

--- a/packages/browser/test/openfeature/provider.spec.ts
+++ b/packages/browser/test/openfeature/provider.spec.ts
@@ -296,6 +296,8 @@ describe('DatadogProvider', () => {
         variant: 'variation-123',
         reason: 'TARGETING_MATCH',
         flagMetadata: {
+          __dd_allocation_key: 'allocation-123',
+          __dd_do_log: true,
           allocationKey: 'allocation-123',
           doLog: true,
           variationType: 'STRING',

--- a/packages/core/src/configuration/configuration.ts
+++ b/packages/core/src/configuration/configuration.ts
@@ -53,10 +53,18 @@ export type PrecomputedFlag<T extends FlagValueType = FlagValueType> = {
 
 /** @internal */
 export type PrecomputedFlagMetadata = {
-  allocationKey: string
-  variationType: FlagValueType
-  doLog: boolean
+  // Standardized keys
+  __dd_allocation_key: string
+  __dd_do_log: boolean
   __dd_split_serial_id?: number
+
+  // Deprecated keys (will be removed in next major version)
+  /** @deprecated Use __dd_allocation_key instead */
+  allocationKey: string
+  /** @deprecated Not used externally, will be removed */
+  variationType: FlagValueType
+  /** @deprecated Use __dd_do_log instead */
+  doLog: boolean
 }
 
 /**

--- a/packages/core/src/configuration/exposureEvent.ts
+++ b/packages/core/src/configuration/exposureEvent.ts
@@ -5,13 +5,15 @@ export function createExposureEvent<T extends FlagValue>(
   context: EvaluationContext,
   details: EvaluationDetails<T>
 ): ExposureEvent | undefined {
-  // Only log if doLog flag is true
-  if (!details.flagMetadata?.doLog) {
+  // Only log if doLog flag is true (prefer new key, fallback to deprecated)
+  const doLog = details.flagMetadata?.__dd_do_log ?? details.flagMetadata?.doLog
+  if (!doLog) {
     return
   }
 
   // Skip logging if allocation key or variant is missing (this should never happen)
-  const allocationKey = details.flagMetadata?.allocationKey as string
+  // Prefer new key, fallback to deprecated
+  const allocationKey = (details.flagMetadata?.__dd_allocation_key ?? details.flagMetadata?.allocationKey) as string
   const variantKey = details.variant
   if (!allocationKey || !variantKey) {
     return

--- a/packages/core/src/configuration/exposureEvent.ts
+++ b/packages/core/src/configuration/exposureEvent.ts
@@ -5,15 +5,13 @@ export function createExposureEvent<T extends FlagValue>(
   context: EvaluationContext,
   details: EvaluationDetails<T>
 ): ExposureEvent | undefined {
-  // Only log if doLog flag is true (prefer new key, fallback to deprecated)
-  const doLog = details.flagMetadata?.__dd_do_log ?? details.flagMetadata?.doLog
-  if (!doLog) {
+  // Only log if doLog flag is true
+  if (!details.flagMetadata?.__dd_do_log) {
     return
   }
 
   // Skip logging if allocation key or variant is missing (this should never happen)
-  // Prefer new key, fallback to deprecated
-  const allocationKey = (details.flagMetadata?.__dd_allocation_key ?? details.flagMetadata?.allocationKey) as string
+  const allocationKey = details.flagMetadata?.__dd_allocation_key as string
   const variantKey = details.variant
   if (!allocationKey || !variantKey) {
     return

--- a/packages/core/src/configuration/flagEvaluationAggregator.ts
+++ b/packages/core/src/configuration/flagEvaluationAggregator.ts
@@ -55,8 +55,7 @@ export class FlagEvaluationAggregator {
       }
     } else {
       const runtimeDefaultUsed = details.reason === 'DEFAULT' || details.reason === 'ERROR'
-      // Prefer new key, fallback to deprecated
-      const allocationKey = (details.flagMetadata?.__dd_allocation_key ?? details.flagMetadata?.allocationKey) as string
+      const allocationKey = details.flagMetadata?.__dd_allocation_key as string
       const targetingRuleKey = details.flagMetadata?.targetingRuleKey as string
       const { targetingKey, ...targetingContext } = context
 
@@ -93,8 +92,7 @@ export class FlagEvaluationAggregator {
     details: EvaluationDetails<T>,
     error?: string
   ): string {
-    // Prefer new key, fallback to deprecated
-    const allocationKey = (details.flagMetadata?.__dd_allocation_key ?? details.flagMetadata?.allocationKey) as string
+    const allocationKey = details.flagMetadata?.__dd_allocation_key as string
     const targetingRuleKey = details.flagMetadata?.targetingRuleKey as string
     const { targetingKey, ...targetingContext } = context
 

--- a/packages/core/src/configuration/flagEvaluationAggregator.ts
+++ b/packages/core/src/configuration/flagEvaluationAggregator.ts
@@ -55,7 +55,8 @@ export class FlagEvaluationAggregator {
       }
     } else {
       const runtimeDefaultUsed = details.reason === 'DEFAULT' || details.reason === 'ERROR'
-      const allocationKey = details.flagMetadata?.allocationKey as string
+      // Prefer new key, fallback to deprecated
+      const allocationKey = (details.flagMetadata?.__dd_allocation_key ?? details.flagMetadata?.allocationKey) as string
       const targetingRuleKey = details.flagMetadata?.targetingRuleKey as string
       const { targetingKey, ...targetingContext } = context
 
@@ -92,7 +93,8 @@ export class FlagEvaluationAggregator {
     details: EvaluationDetails<T>,
     error?: string
   ): string {
-    const allocationKey = details.flagMetadata?.allocationKey as string
+    // Prefer new key, fallback to deprecated
+    const allocationKey = (details.flagMetadata?.__dd_allocation_key ?? details.flagMetadata?.allocationKey) as string
     const targetingRuleKey = details.flagMetadata?.targetingRuleKey as string
     const { targetingKey, ...targetingContext } = context
 

--- a/packages/core/test/configuration/flagEvaluationAggregator.spec.ts
+++ b/packages/core/test/configuration/flagEvaluationAggregator.spec.ts
@@ -24,7 +24,7 @@ describe('FlagEvaluationAggregator', () => {
       variant: 'variant-a',
       reason: 'TARGETING_MATCH',
       flagMetadata: {
-        allocationKey: 'allocation-123',
+        __dd_allocation_key: 'allocation-123',
       },
     }
 
@@ -106,7 +106,7 @@ describe('FlagEvaluationAggregator', () => {
       variant: 'variant-a',
       reason: 'TARGETING_MATCH',
       flagMetadata: {
-        allocationKey: 'allocation-123',
+        __dd_allocation_key: 'allocation-123',
       },
     }
 
@@ -155,7 +155,7 @@ describe('FlagEvaluationAggregator', () => {
       variant: 'variant-a', // Same variant
       reason: 'TARGETING_MATCH',
       flagMetadata: {
-        allocationKey: 'allocation-123',
+        __dd_allocation_key: 'allocation-123',
       },
     }
 
@@ -251,7 +251,7 @@ describe('FlagEvaluationAggregator', () => {
       variant: 'variant-a',
       reason: 'TARGETING_MATCH',
       flagMetadata: {
-        allocationKey: 'allocation-123',
+        __dd_allocation_key: 'allocation-123',
       },
     }
 
@@ -321,7 +321,7 @@ describe('FlagEvaluationAggregator', () => {
       variant: 'variant-a',
       reason: 'TARGETING_MATCH',
       flagMetadata: {
-        allocationKey: 'allocation-123',
+        __dd_allocation_key: 'allocation-123',
       },
     }
 
@@ -365,7 +365,7 @@ describe('FlagEvaluationAggregator', () => {
       variant: 'variant-a',
       reason: 'TARGETING_MATCH',
       flagMetadata: {
-        allocationKey: 'allocation-123',
+        __dd_allocation_key: 'allocation-123',
       },
     }
 

--- a/packages/node-server/src/configuration/evaluateForSubject.ts
+++ b/packages/node-server/src/configuration/evaluateForSubject.ts
@@ -88,10 +88,14 @@ export function evaluateForSubject<T extends FlagValueType>(
           reason: StandardResolutionReasons.TARGETING_MATCH,
           variant: variant.key,
           flagMetadata: {
+            // Standardized keys
+            __dd_allocation_key: allocation.key,
+            __dd_do_log: !!allocation.doLog,
+            __dd_split_serial_id: selectedSplit.serialId,
+            // Deprecated keys (for backwards compatibility)
             allocationKey: allocation.key,
             variationType: variantTypeToFlagValueType(flag.variationType),
             doLog: !!allocation.doLog,
-            __dd_split_serial_id: selectedSplit.serialId,
           } as PrecomputedFlagMetadata,
         }
       }


### PR DESCRIPTION
## Motivation

Standardize flagMetadata key names to follow the libdatadog convention (`__dd_` prefix + snake_case). This enables system-tests to validate flag metadata across SDKs.

Related:
* [libdatadog#1940](https://github.com/DataDog/libdatadog/pull/1940)
* https://github.com/DataDog/openfeature-js-client/pull/269/changes/BASE..60b0554f57b44ed75ec4d1fc60394c392b1d0b90#r3218694823

## Changes

- Add `__dd_allocation_key` and `__dd_do_log` as standardized keys in `PrecomputedFlagMetadata`
- Mark `allocationKey`, `doLog`, and `variationType` as `@deprecated`
- Writers (evaluateForSubject.ts, browser/evaluation.ts) set both old and new keys
- Readers (exposureEvent.ts, flagEvaluationAggregator.ts) prefer new keys with fallback to deprecated

## Test instructions

```bash
npm test
```

All 383 tests pass (26 core + 242 node-server + 115 browser).

## Checklist

- [ ] Updated Documentation
- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.