### PR TITLE
v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ---
 
+## v1.1.3
+
+**Internal Changes:**
+
+- feat(node): expose serialId in flagMetadata for span enrichment ([#269](https://github.com/DataDog/openfeature-js-client/pull/269)) [NODE-SERVER]
+- 👷 ci(deps): Bump dependabot/fetch-metadata ([#267](https://github.com/DataDog/openfeature-js-client/pull/267))
+
 ## v1.1.2
 
 **Internal Changes:**

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "npmClient": "yarn",
-  "version": "1.1.2"
+  "version": "1.1.3"
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-browser",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Browser-specific bindings for OpenFeature (wraps @datadog/openfeature-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@datadog/browser-core": "^6.33.0",
-    "@datadog/flagging-core": "1.1.2"
+    "@datadog/flagging-core": "1.1.3"
   },
   "peerDependencies": {
     "@openfeature/core": "^1.9.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/flagging-core",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Runtime-agnostic flag-evaluation logic for Datadog Flagging",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-node-server",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Node.js server bindings for OpenFeature (wraps @datadog/flagging-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",

--- a/yarn.lock
+++ b/yarn.lock
@@ -659,7 +659,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/flagging-core@npm:1.1.2, @datadog/flagging-core@workspace:^, @datadog/flagging-core@workspace:packages/core":
+"@datadog/flagging-core@npm:1.1.3, @datadog/flagging-core@workspace:^, @datadog/flagging-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@datadog/flagging-core@workspace:packages/core"
   dependencies:
@@ -681,7 +681,7 @@ __metadata:
   resolution: "@datadog/openfeature-browser@workspace:packages/browser"
   dependencies:
     "@datadog/browser-core": "npm:^6.33.0"
-    "@datadog/flagging-core": "npm:1.1.2"
+    "@datadog/flagging-core": "npm:1.1.3"
     "@openfeature/core": "npm:^1.9.2"
     "@openfeature/web-sdk": "npm:^1.5.0"
     "@types/chrome": "npm:^0.1.18"


### PR DESCRIPTION
## Release v1.1.3

### Changes

- feat(node): expose serialId in flagMetadata for span enrichment ([#269](https://github.com/DataDog/openfeature-js-client/pull/269)) [NODE-SERVER]
- 👷 ci(deps): Bump dependabot/fetch-metadata ([#267](https://github.com/DataDog/openfeature-js-client/pull/267))

### Checklist

- [x] Version bumped via `lerna version`
- [x] CHANGELOG.md updated
- [ ] Create GitHub Release after merge (tag: `v1.1.3`)