### PR TITLE
fix: remove workspace:^ version specifier from node-server package

### DIFF
--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -36,7 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@datadog/flagging-core": "workspace:^"
+    "@datadog/flagging-core": "1.2.0"
   },
   "peerDependencies": {
     "@openfeature/server-sdk": ">=1.15.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -659,7 +659,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/flagging-core@npm:1.2.0, @datadog/flagging-core@workspace:^, @datadog/flagging-core@workspace:packages/core":
+"@datadog/flagging-core@npm:1.2.0, @datadog/flagging-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@datadog/flagging-core@workspace:packages/core"
   dependencies:
@@ -731,7 +731,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/openfeature-node-server@workspace:packages/node-server"
   dependencies:
-    "@datadog/flagging-core": "workspace:^"
+    "@datadog/flagging-core": "npm:1.2.0"
     "@openfeature/core": "npm:1.9.2"
     "@openfeature/server-sdk": "npm:1.20.2"
     "@types/jest": "npm:^30.0.0"


### PR DESCRIPTION
workspace:^ is a yarn feature and it automatically replaces it with a proper version on publish. Unfortunately, our release script used npm to publish, which kept it verbatim and caused installation issues for users down the line.

Revert workspace:^ version specifier and use regular version specifier so npm can publish it normally.
