### PR TITLE
browser: expose flag metadata in flagMetadata from precomputed assignments

### DIFF
--- a/packages/browser/src/evaluation.ts
+++ b/packages/browser/src/evaluation.ts
@@ -51,6 +51,8 @@ function evaluatePrecomputed<T extends FlagValueType>(
     value: flag.variationValue as FlagTypeToValue<T>,
     variant: flag.variationKey,
     flagMetadata: {
+      // Spread backend metadata first so SDK-internal keys win on collision.
+      ...(flag.metadata ?? {}),
       allocationKey: flag.allocationKey,
       variationType: flag.variationType,
       doLog: flag.doLog,

--- a/packages/core/src/configuration/configuration.ts
+++ b/packages/core/src/configuration/configuration.ts
@@ -40,6 +40,13 @@ export type PrecomputedConfigurationResponse = {
   }
 }
 
+/** @internal
+ * Generic passthrough metadata from the FFE backend (e.g. version,
+ * lastModified). Values are restricted to the primitive types that
+ * OpenFeature's FlagMetadata spec allows (string | number | boolean).
+ */
+export type FlagMetadata = Record<string, string | number | boolean>
+
 /** @internal */
 export type PrecomputedFlag<T extends FlagValueType = FlagValueType> = {
   allocationKey: string
@@ -49,11 +56,17 @@ export type PrecomputedFlag<T extends FlagValueType = FlagValueType> = {
   reason: ResolutionReason
   doLog: boolean
   extraLogging: Record<string, unknown>
+  /** @internal Backend-emitted metadata. Surfaced in flagMetadata. */
+  metadata?: FlagMetadata
 }
 
-/** @internal */
+/** @internal
+ * SDK-internal keys (allocationKey, variationType, doLog) take precedence on
+ * collision with backend metadata. The intersection widens to FlagMetadata so
+ * passthrough keys like `version` survive end-to-end.
+ */
 export type PrecomputedFlagMetadata = {
   allocationKey: string
   variationType: FlagValueType
   doLog: boolean
-}
+} & FlagMetadata


### PR DESCRIPTION
## Summary

- Adds `FlagMetadata = Record<string, string | number | boolean>` type to `@datadog/flagging-core`
- Adds a `metadata?: FlagMetadata` field to `PrecomputedFlag` so that backend-emitted flag metadata (version, lastModified, etc.) is carried through deserialization
- In `evaluatePrecomputed`, spreads `flag.metadata` into the returned `flagMetadata` before SDK-internal keys so SDK keys win on collision

After this change, `client.getBooleanDetails("my-flag", false, ctx).flagMetadata.version` returns the flag's current version number from the backend.

## Test plan

- [ ] `yarn build` passes across all three packages
- [ ] Add `metadata: { version: 42 }` to the precompute fixture in `packages/browser/test/evaluation.spec.ts` and assert `details.flagMetadata.version === 42`