### PR TITLE
v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@
 
 ---
 
+## v1.2.2
+
+**Internal Changes:**
+
+- chore: pin exact versions for internal dependencies ([#283](https://github.com/DataDog/openfeature-js-client/pull/283))
+- ci: add npm compatibility smoke test ([#282](https://github.com/DataDog/openfeature-js-client/pull/282))
+
+## v1.2.1
+
+**Internal Changes:**
+
+- fix: remove workspace:^ version specifier from node-server package ([#280](https://github.com/DataDog/openfeature-js-client/pull/280)) [NODE-SERVER]
+
 ## v1.2.0
 
 **Internal Changes:**

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "npmClient": "yarn",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "command": {
     "version": {
       "exact": true

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-browser",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Browser-specific bindings for OpenFeature (wraps @datadog/openfeature-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@datadog/browser-core": "^6.33.0",
-    "@datadog/flagging-core": "^1.2.1"
+    "@datadog/flagging-core": "1.2.2"
   },
   "peerDependencies": {
     "@openfeature/core": "^1.9.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/flagging-core",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Runtime-agnostic flag-evaluation logic for Datadog Flagging",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-node-server",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Node.js server bindings for OpenFeature (wraps @datadog/flagging-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",
@@ -36,7 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@datadog/flagging-core": "^1.2.1"
+    "@datadog/flagging-core": "1.2.2"
   },
   "peerDependencies": {
     "@openfeature/server-sdk": ">=1.15.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -659,7 +659,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/flagging-core@npm:^1.2.1, @datadog/flagging-core@workspace:packages/core":
+"@datadog/flagging-core@npm:1.2.2, @datadog/flagging-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@datadog/flagging-core@workspace:packages/core"
   dependencies:
@@ -681,7 +681,7 @@ __metadata:
   resolution: "@datadog/openfeature-browser@workspace:packages/browser"
   dependencies:
     "@datadog/browser-core": "npm:^6.33.0"
-    "@datadog/flagging-core": "npm:^1.2.1"
+    "@datadog/flagging-core": "npm:1.2.2"
     "@openfeature/core": "npm:^1.9.2"
     "@openfeature/web-sdk": "npm:^1.5.0"
     "@types/chrome": "npm:^0.1.18"
@@ -731,7 +731,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/openfeature-node-server@workspace:packages/node-server"
   dependencies:
-    "@datadog/flagging-core": "npm:^1.2.1"
+    "@datadog/flagging-core": "npm:1.2.2"
     "@openfeature/core": "npm:1.9.2"
     "@openfeature/server-sdk": "npm:1.20.2"
     "@types/jest": "npm:^30.0.0"


### PR DESCRIPTION
## Release v1.2.2

### Changes

- chore: pin exact versions for internal dependencies ([#283](https://github.com/DataDog/openfeature-js-client/pull/283))
- ci: add npm compatibility smoke test ([#282](https://github.com/DataDog/openfeature-js-client/pull/282))

### Key Fix

The `@datadog/openfeature-node-server` and `@datadog/openfeature-browser` packages now declare **exact versions** for their internal dependency on `@datadog/flagging-core`:

| Package | Before (v1.2.1) | After (v1.2.2) |
|---------|-----------------|----------------|
| `@datadog/openfeature-node-server` | `"@datadog/flagging-core": "^1.2.1"` | `"@datadog/flagging-core": "1.2.2"` |
| `@datadog/openfeature-browser` | `"@datadog/flagging-core": "^1.2.1"` | `"@datadog/flagging-core": "1.2.2"` |

### Why a Patch Release

[A major bump was proposed](https://github.com/DataDog/openfeature-js-client/pull/283#discussion_r3247736748), but a patch is safe because no consumers have installed yet with the loose versioning—see timeline below.

### Timeline: loose versioning never made it into `dd-trace-js`

| Time (UTC) | Event |
|------------|-------|
| 2026-05-13 06:06 | **v1.2.0 published** - Broken due to `workspace:^` protocol. npm installs failed (`https://github.com/DataDog/dd-trace-js/issues/8455`) |
| 2026-05-13 (same day) | **dd-trace-js [PR #8456](https://github.com/DataDog/dd-trace-js/pull/8456) merged** - Pinned dependency from `^1.1.2` → `1.1.2` (exact) |
| 2026-05-13 10:02 | **v1.2.1 published** - Fixed workspace:^ issue, but dd-trace-js already pinned to 1.1.2 |
| 2026-05-18 | **v1.2.2 (this release)** - Restores exact internal versioning |

dd-trace-js master is still on `1.1.2`—it never updated to 1.2.x. The loose caret versioning was never propagated to users.

### Code Diff

https://github.com/DataDog/openfeature-js-client/compare/v1.2.1...v1.2.2

### Checklist

- [x] Version bumped via `lerna version`
- [x] CHANGELOG.md updated
- [ ] Create GitHub Release after merge (tag: `v1.2.2`)