### PR TITLE
v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@
 
 ---
 
+## v2.0.0
+
+**Breaking Changes:**
+
+- chore: pin exact versions for internal dependencies ([#283](https://github.com/DataDog/openfeature-js-client/pull/283))
+
+  The `@datadog/openfeature-node-server` and `@datadog/openfeature-browser` packages now declare **exact versions** for their internal dependency on `@datadog/flagging-core`:
+
+  | Package                            | Before (v1.2.1)                      | After (v2.0.0)                      |
+  | ---------------------------------- | ------------------------------------ | ----------------------------------- |
+  | `@datadog/openfeature-node-server` | `"@datadog/flagging-core": "^1.2.1"` | `"@datadog/flagging-core": "2.0.0"` |
+  | `@datadog/openfeature-browser`     | `"@datadog/flagging-core": "^1.2.1"` | `"@datadog/flagging-core": "2.0.0"` |
+
+  **Why a major bump?**
+
+  Users of `dd-trace-js` v5.89.0 through v5.102.0 have `"@datadog/openfeature-node-server": "^1.1.x"` in their dependency tree, which resolves to v1.2.1 with loose internal versioning. A major version ensures these users must explicitly opt-in to the new versioning scheme.
+
+**Internal Changes:**
+
+- ci: add npm compatibility smoke test ([#282](https://github.com/DataDog/openfeature-js-client/pull/282))
+
 ## v1.2.0
 
 **Internal Changes:**

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "npmClient": "yarn",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "command": {
     "version": {
       "exact": true

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-browser",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Browser-specific bindings for OpenFeature (wraps @datadog/openfeature-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@datadog/browser-core": "^6.33.0",
-    "@datadog/flagging-core": "^1.2.1"
+    "@datadog/flagging-core": "2.0.0"
   },
   "peerDependencies": {
     "@openfeature/core": "^1.9.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/flagging-core",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Runtime-agnostic flag-evaluation logic for Datadog Flagging",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-node-server",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Node.js server bindings for OpenFeature (wraps @datadog/flagging-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",
@@ -36,7 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@datadog/flagging-core": "^1.2.1"
+    "@datadog/flagging-core": "2.0.0"
   },
   "peerDependencies": {
     "@openfeature/server-sdk": ">=1.15.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -659,7 +659,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/flagging-core@npm:^1.2.1, @datadog/flagging-core@workspace:packages/core":
+"@datadog/flagging-core@npm:2.0.0, @datadog/flagging-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@datadog/flagging-core@workspace:packages/core"
   dependencies:
@@ -681,7 +681,7 @@ __metadata:
   resolution: "@datadog/openfeature-browser@workspace:packages/browser"
   dependencies:
     "@datadog/browser-core": "npm:^6.33.0"
-    "@datadog/flagging-core": "npm:^1.2.1"
+    "@datadog/flagging-core": "npm:2.0.0"
     "@openfeature/core": "npm:^1.9.2"
     "@openfeature/web-sdk": "npm:^1.5.0"
     "@types/chrome": "npm:^0.1.18"
@@ -731,7 +731,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/openfeature-node-server@workspace:packages/node-server"
   dependencies:
-    "@datadog/flagging-core": "npm:^1.2.1"
+    "@datadog/flagging-core": "npm:2.0.0"
     "@openfeature/core": "npm:1.9.2"
     "@openfeature/server-sdk": "npm:1.20.2"
     "@types/jest": "npm:^30.0.0"


### PR DESCRIPTION
## Release v2.0.0

### Breaking Changes

The `@datadog/openfeature-node-server` and `@datadog/openfeature-browser` packages now declare **exact versions** for their internal dependency on `@datadog/flagging-core`:

| Package | Before (v1.2.1) | After (v2.0.0) |
|---------|-----------------|----------------|
| `@datadog/openfeature-node-server` | `"@datadog/flagging-core": "^1.2.1"` | `"@datadog/flagging-core": "2.0.0"` |
| `@datadog/openfeature-browser` | `"@datadog/flagging-core": "^1.2.1"` | `"@datadog/flagging-core": "2.0.0"` |

### Why a Major Bump?

Users of `dd-trace-js` v5.89.0 through v5.102.0 have `"@datadog/openfeature-node-server": "^1.1.x"` in their dependency tree, which currently resolves to v1.2.1 with loose internal `^` versioning.

A major version ensures these users must explicitly opt-in to the new versioning scheme and won't accidentally receive future flagging-core updates through the loose caret constraint.

### dd-trace-js Dependency History

| dd-trace version | openfeature-node-server dep | Notes |
|------------------|---------------------------|-------|
| v5.72.0 - v5.78.0 | `"0.1.0-preview.x"` | Exact (pinned) |
| v5.79.0 - v5.88.0 | `"^0.2.0"` to `"^0.3.3"` | Caret, but won't resolve to 1.x |
| **v5.89.0 - v5.102.0** | `"^1.1.0"` to `"^1.1.2"` | **Caret - resolves to 1.2.1** |
| v5.103.0+ | `"1.1.2"` | Exact (pinned) |

### Changes

- chore: pin exact versions for internal dependencies ([#283](https://github.com/DataDog/openfeature-js-client/pull/283))
- ci: add npm compatibility smoke test ([#282](https://github.com/DataDog/openfeature-js-client/pull/282))

### Code Diff

https://github.com/DataDog/openfeature-js-client/compare/v1.2.1...v2.0.0

### Checklist

- [x] Version bumped via `yarn release`
- [x] CHANGELOG.md updated
- [ ] Create GitHub Release after merge (tag: `v2.0.0`)