### PR TITLE
chore: switch to lerna independent versioning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,16 +18,45 @@ jobs:
 
       - name: Validate release version
         run: |
-          # Check if the tag matches the version in lerna.json
-          RELEASE_VERSION="${{ github.event.release.tag_name }}"
-          LERNA_VERSION=$(node -p "require('./lerna.json').version")
+          # Parse the release tag to extract package and version
+          # Independent versioning tags: @datadog/package-name@1.2.3 or v1.2.3 (for all packages)
+          RELEASE_TAG="${{ github.event.release.tag_name }}"
 
-          if [[ "v$LERNA_VERSION" != "$RELEASE_VERSION" ]]; then
-            echo "❌ Release tag $RELEASE_VERSION doesn't match lerna.json version v$LERNA_VERSION"
+          if [[ "$RELEASE_TAG" =~ ^@datadog/(.+)@(.+)$ ]]; then
+            # Independent package release (e.g., @datadog/openfeature-node-server@1.3.0)
+            PKG_NAME="${BASH_REMATCH[1]}"
+            TAG_VERSION="${BASH_REMATCH[2]}"
+
+            # Map package name to directory
+            case "$PKG_NAME" in
+              "flagging-core") PKG_DIR="packages/core" ;;
+              "openfeature-browser") PKG_DIR="packages/browser" ;;
+              "openfeature-node-server") PKG_DIR="packages/node-server" ;;
+              *) echo "❌ Unknown package: $PKG_NAME"; exit 1 ;;
+            esac
+
+            PKG_VERSION=$(node -p "require('./$PKG_DIR/package.json').version")
+            if [[ "$PKG_VERSION" != "$TAG_VERSION" ]]; then
+              echo "❌ Release tag version $TAG_VERSION doesn't match $PKG_DIR version $PKG_VERSION"
+              exit 1
+            fi
+            echo "✅ Release validation passed for @datadog/$PKG_NAME@$TAG_VERSION"
+          elif [[ "$RELEASE_TAG" =~ ^v(.+)$ ]]; then
+            # Legacy unified release (e.g., v1.2.1) - validate all packages have same version
+            TAG_VERSION="${BASH_REMATCH[1]}"
+            for pkg_dir in packages/core packages/browser packages/node-server; do
+              PKG_VERSION=$(node -p "require('./$pkg_dir/package.json').version")
+              if [[ "$PKG_VERSION" != "$TAG_VERSION" ]]; then
+                echo "❌ Release tag v$TAG_VERSION doesn't match $pkg_dir version $PKG_VERSION"
+                exit 1
+              fi
+            done
+            echo "✅ Release validation passed for unified release v$TAG_VERSION"
+          else
+            echo "❌ Invalid release tag format: $RELEASE_TAG"
+            echo "Expected: @datadog/package-name@x.y.z or vx.y.z"
             exit 1
           fi
-
-          echo "✅ Release validation passed"
 
       - name: Validate internal dependencies use exact versions
         run: bash scripts/internal-deps-validate.sh
@@ -77,41 +106,63 @@ jobs:
             echo "Using 'alpha' npm tag for prerelease $RELEASE_TAG"
           fi
 
-      - name: Publish all packages
+      - name: Publish packages
         run: |
-          VERSION=$(node -p "require('./lerna.json').version")
-          TAG="${{ steps.npm-tag.outputs.tag }}"
+          RELEASE_TAG="${{ github.event.release.tag_name }}"
+          NPM_TAG="${{ steps.npm-tag.outputs.tag }}"
 
           publish_package() {
             local pkg_dir=$1
             local pkg_name=$(node -p "require('./$pkg_dir/package.json').name")
+            local pkg_version=$(node -p "require('./$pkg_dir/package.json').version")
 
-            if npm view "$pkg_name@$VERSION" --json > /dev/null 2>&1; then
-              echo "⏭️  $pkg_name@$VERSION already published, skipping"
+            if npm view "$pkg_name@$pkg_version" --json > /dev/null 2>&1; then
+              echo "⏭️  $pkg_name@$pkg_version already published, skipping"
               return 0
             fi
 
-            echo "📦 Publishing $pkg_name@$VERSION..."
+            echo "📦 Publishing $pkg_name@$pkg_version..."
             cd "$pkg_dir"
-            npm publish --provenance --tag "$TAG"
+            npm publish --provenance --tag "$NPM_TAG"
             cd -
           }
 
-          publish_package packages/core
+          wait_for_core() {
+            local core_version=$(node -p "require('./packages/core/package.json').version")
+            echo "Waiting for @datadog/flagging-core@$core_version to propagate..."
+            for i in {1..30}; do
+              if npm view "@datadog/flagging-core@$core_version" --json > /dev/null 2>&1; then
+                echo "✅ @datadog/flagging-core@$core_version is available"
+                return 0
+              fi
+              if [ $i -eq 30 ]; then
+                echo "❌ Timeout waiting for core package"
+                exit 1
+              fi
+              sleep 10
+            done
+          }
 
-          # Wait for core to propagate before publishing dependents
-          echo "Waiting for @datadog/flagging-core@$VERSION to propagate..."
-          for i in {1..30}; do
-            if npm view "@datadog/flagging-core@$VERSION" --json > /dev/null 2>&1; then
-              echo "✅ @datadog/flagging-core@$VERSION is available"
-              break
-            fi
-            if [ $i -eq 30 ]; then
-              echo "❌ Timeout waiting for core package"
-              exit 1
-            fi
-            sleep 10
-          done
-
-          publish_package packages/browser
-          publish_package packages/node-server
+          if [[ "$RELEASE_TAG" =~ ^@datadog/(.+)@(.+)$ ]]; then
+            # Independent package release - publish only the specified package
+            PKG_NAME="${BASH_REMATCH[1]}"
+            case "$PKG_NAME" in
+              "flagging-core")
+                publish_package packages/core
+                ;;
+              "openfeature-browser")
+                wait_for_core
+                publish_package packages/browser
+                ;;
+              "openfeature-node-server")
+                wait_for_core
+                publish_package packages/node-server
+                ;;
+            esac
+          else
+            # Unified release (vX.Y.Z) - publish all packages
+            publish_package packages/core
+            wait_for_core
+            publish_package packages/browser
+            publish_package packages/node-server
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -127,6 +127,8 @@ jobs:
             cd -
           }
 
+          # Dependent packages need flagging-core available on npm registry before publishing.
+          # This handles both fresh publishes and verifies existing versions are accessible.
           wait_for_core() {
             local core_version=$(node -p "require('./packages/core/package.json').version")
             echo "Waiting for @datadog/flagging-core@$core_version to propagate..."
@@ -157,6 +159,10 @@ jobs:
               "openfeature-node-server")
                 wait_for_core
                 publish_package packages/node-server
+                ;;
+              *)
+                echo "❌ Unknown package: $PKG_NAME"
+                exit 1
                 ;;
             esac
           else

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,9 @@ This is a monorepo managed with Lerna that contains multiple packages:
 
 - **`@datadog/flagging-core`** - Runtime-agnostic flag-evaluation logic
 - **`@datadog/openfeature-browser`** - Browser-specific bindings for OpenFeature
+- **`@datadog/openfeature-node-server`** - Node.js server bindings for OpenFeature
 
-The project uses **fixed versioning**, meaning all packages share the same version number and are released together. The version is managed centrally in `lerna.json`.
+The project uses **independent versioning**, meaning each package can have its own version number. Internal dependencies (e.g., `@datadog/flagging-core`) are pinned to exact versions to prevent version skew.
 
 ## Development Setup
 
@@ -196,21 +197,20 @@ yarn pack
 
 ### Version Management
 
-Since this project uses **fixed versioning**:
+Since this project uses **independent versioning**:
 
-- All packages share the same version number (managed in `lerna.json`)
-- When running `yarn release`, Lerna will prompt for a single version update
-- All package versions are automatically synchronized
-- Peer dependencies are automatically updated to match the fixed version
-- A single version commit and tag is created for the entire project
+- Each package has its own version number (stored in its `package.json`)
+- When running `yarn release`, Lerna will prompt for version updates per changed package
+- Internal dependencies are pinned to exact versions (configured via `command.version.exact` in `lerna.json`)
+- Version commits and tags are created per package (e.g., `@datadog/openfeature-node-server@1.3.0`)
 
 ### Automated Release Workflow Details
 
 The GitHub Actions workflow (`release.yaml`) includes several safety measures:
 
 1. **Version Consistency Check:**
-   - Compares GitHub release tag with `lerna.json` version
-   - Ensures tags and versions are synchronized
+   - Compares GitHub release tag with the corresponding package version
+   - Ensures tags and package versions are synchronized
 
 2. **Dependency Coordination:**
    - Core package is published first

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,6 +204,8 @@ Since this project uses **independent versioning**:
 - Internal dependencies are pinned to exact versions (configured via `command.version.exact` in `lerna.json`)
 - Version commits and tags are created per package (e.g., `@datadog/openfeature-node-server@1.3.0`)
 
+> ⚠️ **Warning:** `@datadog/flagging-core` cannot be safely updated within the 1.x range. Users on `openfeature-node-server@1.2.1` have a `^1.2.1` constraint and would pull any new 1.x version, causing version skew. A major bump to `2.0.0` is required for any future `flagging-core` changes.
+
 ### Automated Release Workflow Details
 
 The GitHub Actions workflow (`release.yaml`) includes several safety measures:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,30 +96,62 @@ All packages are published with the `latest` npm tag.
    git checkout -b release/v1.2.3
    ```
 
-#### Step 2: Prepare Package Dependencies
+#### Step 2: Pin Internal Dependencies
 
-2. **Update the version using the CLI:**
+2. **Ensure internal dependencies use exact versions:**
 
+   ```bash
+   yarn node ./scripts/release/update-peer-dependency-versions.js
+   ```
+
+   This script reads each package's current version and updates internal dependencies (like `@datadog/flagging-core`) to use exact versions without the `^` prefix. This prevents version skew between packages.
+
+   After running, verify the changes:
+   ```bash
+   git diff packages/*/package.json
+   ```
+
+   You should see changes like:
+   ```diff
+   -    "@datadog/flagging-core": "^1.2.1"
+   +    "@datadog/flagging-core": "1.2.1"
+   ```
+
+#### Step 3: Version the Package(s)
+
+3. **Update the version using the CLI:**
+
+   **For independent releases (recommended):**
    ```bash
    yarn release
    ```
 
    This command:
    - Validates you're not on the `main` branch
-   - Runs `lerna version --exact --force-publish` to update the version
-   - Prompts for the new version number (applied to all packages)
-   - Creates version commits and tags
-   - Updates all package versions to match
-   - Pushes version tag to Github
+   - Runs `lerna version --exact`
+   - Prompts for version updates only for **changed** packages
+   - Creates version commits and tags per package (e.g., `@datadog/openfeature-node-server@1.3.0`)
+   - Pushes version tags to Github
 
-#### Step 3: Publish via GitHub Release
+   **For unified releases (all packages with same version):**
+   ```bash
+   yarn release:all
+   ```
+
+   This command:
+   - Same as above, but uses `--force-publish` to prompt for **all** packages
+   - Use this when you want to release all packages together with the same version
+
+#### Step 4: Publish via GitHub Release
 
 **Publishing is fully automated via GitHub workflows!**
 
 1. **Create a GitHub Release:**
    - Go to the GitHub repository
    - Click "Releases" → "Create a new release"
-   - Set the tag to match your version (e.g., `v1.1.0`)
+   - Set the tag to match your version:
+     - Independent: `@datadog/openfeature-node-server@1.3.0` (publishes only that package)
+     - Unified: `v1.2.1` (publishes all packages)
    - Add release notes describing your changes or use the `Generate Release Notes` button
    - Click "Publish release"
 
@@ -128,7 +160,7 @@ All packages are published with the `latest` npm tag.
    The `release.yaml` workflow will automatically trigger and:
 
    **Validation Phase:**
-   - Checks that the GitHub release tag matches the version in `lerna.json`
+   - Checks that the GitHub release tag matches the corresponding package version
    - Fails fast if validation doesn't pass
 
    **Build and Publish Phase:**
@@ -137,13 +169,16 @@ All packages are published with the `latest` npm tag.
    - Creates package tarballs with `yarn lerna run pack --stream`
 
    **Publishing Sequence:**
-   1. **Publishes core package first** (`@datadog/flagging-core`)
-   2. **Waits for npm registry propagation**
-      - Polls npm registry for up to 5 minutes
-      - Ensures core package is available before proceeding
-      - Prevents dependency resolution issues
-   3. **Publishes browser package** (`@datadog/openfeature-browser`)
-   4. **Publishes node-server package** (`@datadog/openfeature-node-server`)
+
+   *For independent releases* (`@datadog/pkg@x.y.z`):
+   - Publishes only the specified package
+   - If publishing `browser` or `node-server`, waits for `flagging-core` to be available on npm first
+
+   *For unified releases* (`vX.Y.Z`):
+   1. Publishes `@datadog/flagging-core` first
+   2. Waits for npm registry propagation (up to 5 minutes)
+   3. Publishes `@datadog/openfeature-browser`
+   4. Publishes `@datadog/openfeature-node-server`
 
 ### Package-Specific Build Commands
 
@@ -200,7 +235,8 @@ yarn pack
 Since this project uses **independent versioning**:
 
 - Each package has its own version number (stored in its `package.json`)
-- When running `yarn release`, Lerna will prompt for version updates per changed package
+- `yarn release` prompts for version updates only for **changed** packages (independent releases)
+- `yarn release:all` prompts for **all** packages (unified releases)
 - Internal dependencies are pinned to exact versions (configured via `command.version.exact` in `lerna.json`)
 - Version commits and tags are created per package (e.g., `@datadog/openfeature-node-server@1.3.0`)
 
@@ -254,7 +290,7 @@ The GitHub Actions workflow (`release.yaml`) includes several safety measures:
 
 5. **Package creation test:**
    ```bash
-   yarn version  # Test dependency updates and package creation
+   yarn version  # Pins internal dependencies and creates package tarballs
    ```
 
 ### Troubleshooting
@@ -274,8 +310,8 @@ The GitHub Actions workflow (`release.yaml`) includes several safety measures:
    - Check that all dependencies are installed
 
 4. **Version synchronization issues:**
-   - Run `yarn version` to update peer dependencies
-   - Check that all package versions match the version in `lerna.json`
+   - Run `yarn node ./scripts/release/update-peer-dependency-versions.js` to pin internal dependencies
+   - Verify internal dependencies use exact versions (no `^` prefix)
 
 5. **GitHub workflow failures:**
    - Check the Actions tab for detailed error logs
@@ -299,7 +335,7 @@ The GitHub Actions workflow (`release.yaml`) includes several safety measures:
 - Check the [README.md](README.md) for basic project information
 - Review the scripts in the `scripts/` directory for implementation details
 - Check the GitHub Actions tab for workflow status and logs
-- Examine the `scripts/cli` script for available commands (`release`, `version`, `typecheck`, `lint`)
+- Examine the `scripts/cli` script for available commands (`release`, `release_all`, `version`, `typecheck`, `lint`)
 - Open an issue on GitHub for bugs or feature requests
 
 #### Manual Publishing (Emergency Only)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,10 +94,11 @@ All packages are published with the `latest` npm tag.
 1. **Switch to a feature branch:**
 
    ```bash
-   # For independent releases (single package)
-   git checkout -b release/openfeature-node-server-1.3.0
+   # For independent releases (describe what's being released)
+   git checkout -b release/node-server-1.3.0
+   git checkout -b release/browser-and-node-server-1.3.0
 
-   # For unified releases (all packages)
+   # For unified releases (all packages with same version)
    git checkout -b release/v1.2.3
    ```
 
@@ -163,6 +164,8 @@ All packages are published with the `latest` npm tag.
      - Unified: `v1.2.1` (publishes all packages)
    - Add release notes describing your changes or use the `Generate Release Notes` button
    - Click "Publish release"
+
+   **For multiple independent releases:** Create a separate GitHub release for each package tag (e.g., one for `@datadog/openfeature-browser@1.3.0` and one for `@datadog/openfeature-node-server@1.3.0`).
 
 2. **Automated Publishing Workflow:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,12 @@ All packages are published with the `latest` npm tag.
 #### Step 1: Prepare for Release
 
 1. **Switch to a feature branch:**
+
    ```bash
+   # For independent releases (single package)
+   git checkout -b release/openfeature-node-server-1.3.0
+
+   # For unified releases (all packages)
    git checkout -b release/v1.2.3
    ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,11 +107,13 @@ All packages are published with the `latest` npm tag.
    This script reads each package's current version and updates internal dependencies (like `@datadog/flagging-core`) to use exact versions without the `^` prefix. This prevents version skew between packages.
 
    After running, verify the changes:
+
    ```bash
    git diff packages/*/package.json
    ```
 
    You should see changes like:
+
    ```diff
    -    "@datadog/flagging-core": "^1.2.1"
    +    "@datadog/flagging-core": "1.2.1"
@@ -122,6 +124,7 @@ All packages are published with the `latest` npm tag.
 3. **Update the version using the CLI:**
 
    **For independent releases (recommended):**
+
    ```bash
    yarn release
    ```
@@ -134,6 +137,7 @@ All packages are published with the `latest` npm tag.
    - Pushes version tags to Github
 
    **For unified releases (all packages with same version):**
+
    ```bash
    yarn release:all
    ```
@@ -170,11 +174,11 @@ All packages are published with the `latest` npm tag.
 
    **Publishing Sequence:**
 
-   *For independent releases* (`@datadog/pkg@x.y.z`):
+   _For independent releases_ (`@datadog/pkg@x.y.z`):
    - Publishes only the specified package
    - If publishing `browser` or `node-server`, waits for `flagging-core` to be available on npm first
 
-   *For unified releases* (`vX.Y.Z`):
+   _For unified releases_ (`vX.Y.Z`):
    1. Publishes `@datadog/flagging-core` first
    2. Waits for npm registry propagation (up to 5 minutes)
    3. Publishes `@datadog/openfeature-browser`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This is a monorepo managed with Lerna that contains multiple packages:
 - **`@datadog/openfeature-browser`** - Browser-specific bindings for OpenFeature
 - **`@datadog/openfeature-node-server`** - Node.js server bindings for OpenFeature
 
-The project uses **independent versioning**, meaning each package can have its own version number. Internal dependencies (e.g., `@datadog/flagging-core`) are pinned to exact versions to prevent version skew.
+The project uses **independent versioning**, meaning each package can have its own version number. Internal dependencies (e.g., `@datadog/flagging-core`) are pinned to exact versions on release (via `command.version.exact` in `lerna.json`) to prevent version skew.
 
 ## Development Setup
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "npmClient": "yarn",
-  "version": "1.2.1",
+  "version": "independent",
   "command": {
     "version": {
       "exact": true

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "typecheck": "lerna run typecheck --stream",
     "clean": "lerna run clean --stream",
     "release": "scripts/cli release",
+    "release:all": "scripts/cli release_all",
     "version": "scripts/cli version",
     "format:check": "prettier --check .",
     "format:fix": "prettier --write .",

--- a/scripts/cli
+++ b/scripts/cli
@@ -33,8 +33,13 @@ cmd_lint () {
 
 cmd_release () {
   [[ `git branch --show-current` != "main" ]] || fail 'please do not release from `main` branch'
-  # We should publish all packages regardless of if there are changes in each.
-  # --force-publish will skip the `lerna changed` check for changed packages
+  # Independent versioning: only prompts for changed packages
+  yarn lerna version --exact
+}
+
+cmd_release_all () {
+  [[ `git branch --show-current` != "main" ]] || fail 'please do not release from `main` branch'
+  # Unified versioning: prompts for all packages (use when releasing all packages with same version)
   yarn lerna version --exact --force-publish
 }
 

--- a/scripts/release/update-peer-dependency-versions.js
+++ b/scripts/release/update-peer-dependency-versions.js
@@ -2,41 +2,57 @@ const { runMain } = require('../lib/executionUtils')
 const { modifyFile } = require('../lib/filesUtils')
 const { command } = require('../lib/executionUtils')
 const { packagesDirectoryNames } = require('../lib/packagesDirectoryNames')
+const fs = require('node:fs')
+const path = require('node:path')
 
 const JSON_FILES = packagesDirectoryNames.map((packageName) => `./packages/${packageName}/package.json`)
 
-// This script updates the peer dependency versions between packages to match the new
-// versions during a release. Since we're using fixed versioning, we need to
-// read the version from lerna.json and update all packages to use that version.
+// This script updates internal dependency versions between packages to use exact versions.
+// With independent versioning, each package has its own version in its package.json.
+// This script reads each package's version and updates internal dependencies to match.
 runMain(async () => {
-  // Read the version from lerna.json
-  const lernaJsonPath = require('node:path').join(__dirname, '../../lerna.json')
-  const lernaJson = JSON.parse(await require('node:fs').promises.readFile(lernaJsonPath, 'utf8'))
-  const version = lernaJson.version
+  // Build a map of package name -> version by reading each package's package.json
+  const packageVersions = {}
+  for (const packageDir of packagesDirectoryNames) {
+    const packageJsonPath = path.join(__dirname, '../../packages', packageDir, 'package.json')
+    const packageJson = JSON.parse(await fs.promises.readFile(packageJsonPath, 'utf8'))
+    packageVersions[packageJson.name] = packageJson.version
+  }
 
-  console.log('Updating peer dependency versions to', version)
-  console.log('JSON_FILES', JSON_FILES)
-  const targetDeps = ['@datadog/openfeature-browser', '@datadog/flagging-core']
-  // Update peer dependencies
+  console.log('Package versions:', packageVersions)
+
+  // Internal packages that should use exact versions
+  const internalPackages = ['@datadog/openfeature-browser', '@datadog/flagging-core', '@datadog/openfeature-node-server']
+
+  // Update internal dependencies in each package
   for (const jsonFile of JSON_FILES) {
-    await modifyFile(jsonFile, (content) => updatePackageDependencies(content, version, targetDeps))
+    await modifyFile(jsonFile, (content) => updatePackageDependencies(content, packageVersions, internalPackages))
   }
 
   // update yarn.lock to match the updated JSON files
   command`yarn`.run()
 })
 
-function updatePackageDependencies(content, version, targetDeps) {
+function updatePackageDependencies(content, packageVersions, internalPackages) {
   const json = JSON.parse(content)
+
+  // Update peerDependencies to exact versions
   Object.keys(json.peerDependencies || {})
-    .filter((key) => targetDeps.includes(key))
+    .filter((key) => internalPackages.includes(key))
     .forEach((key) => {
-      json.peerDependencies[key] = version
+      if (packageVersions[key]) {
+        json.peerDependencies[key] = packageVersions[key]
+      }
     })
+
+  // Update dependencies to exact versions
   Object.keys(json.dependencies || {})
-    .filter((key) => targetDeps.includes(key))
+    .filter((key) => internalPackages.includes(key))
     .forEach((key) => {
-      json.dependencies[key] = version
+      if (packageVersions[key]) {
+        json.dependencies[key] = packageVersions[key]
+      }
     })
+
   return `${JSON.stringify(json, null, 2)}\n`
 }

--- a/scripts/release/update-peer-dependency-versions.js
+++ b/scripts/release/update-peer-dependency-versions.js
@@ -22,7 +22,11 @@ runMain(async () => {
   console.log('Package versions:', packageVersions)
 
   // Internal packages that should use exact versions
-  const internalPackages = ['@datadog/openfeature-browser', '@datadog/flagging-core', '@datadog/openfeature-node-server']
+  const internalPackages = [
+    '@datadog/openfeature-browser',
+    '@datadog/flagging-core',
+    '@datadog/openfeature-node-server',
+  ]
 
   // Update internal dependencies in each package
   for (const jsonFile of JSON_FILES) {

--- a/scripts/versions-validate.sh
+++ b/scripts/versions-validate.sh
@@ -6,45 +6,69 @@ package_json_files=$(find . -type f | grep package.json | grep -Ev '(\.git|node_
 
 echo "Validating package versions..."
 
-# Set reference version from lerna.json
-reference_version=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' lerna.json | grep -o '"[0-9][^"]*"' | tr -d '"')
+# Check if using independent or fixed versioning
+lerna_version=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' lerna.json | grep -o '"[^"]*"$' | tr -d '"')
 
-if [ -z "$reference_version" ]; then
-  echo "ERROR: Could not read version from lerna.json"
-  exit 1
-fi
-
-echo "Reference version: $reference_version (from lerna.json)"
-echo ""
-
-mismatches=()
-
-for file in $package_json_files; do
-  # Extract version from package.json if it exists
-  version=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$file" | grep -o '"[0-9][^"]*"' | tr -d '"' || echo "")
-
-  # Skip files without a version field (like the root monorepo package.json)
-  if [ -z "$version" ]; then
-    continue
-  fi
-
-  # Compare against reference version
-  if [ "$version" != "$reference_version" ]; then
-    mismatches+=("$file has version $version (expected $reference_version)")
-  else
-    echo "✓ $file: $version"
-  fi
-done
-
-# Report results
-if [ ${#mismatches[@]} -gt 0 ]; then
+if [ "$lerna_version" = "independent" ]; then
+  echo "Using independent versioning"
   echo ""
-  echo "ERROR: Version mismatches found:"
-  for mismatch in "${mismatches[@]}"; do
-    echo "  - $mismatch"
-  done
-  exit 1
-fi
 
-echo ""
-echo "All package versions match: $reference_version"
+  # For independent versioning, just validate each package has a valid semver version
+  for file in $package_json_files; do
+    version=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$file" | grep -o '"[0-9][^"]*"' | tr -d '"' || echo "")
+
+    if [ -z "$version" ]; then
+      continue
+    fi
+
+    # Basic semver validation (x.y.z with optional prerelease)
+    if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+      echo "✓ $file: $version"
+    else
+      echo "ERROR: $file has invalid version: $version"
+      exit 1
+    fi
+  done
+
+  echo ""
+  echo "All package versions are valid semver"
+else
+  # Fixed versioning - all packages must match lerna.json version
+  reference_version=$(echo "$lerna_version" | grep -o '[0-9][^"]*' || echo "")
+
+  if [ -z "$reference_version" ]; then
+    echo "ERROR: Could not read version from lerna.json"
+    exit 1
+  fi
+
+  echo "Reference version: $reference_version (from lerna.json)"
+  echo ""
+
+  mismatches=()
+
+  for file in $package_json_files; do
+    version=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$file" | grep -o '"[0-9][^"]*"' | tr -d '"' || echo "")
+
+    if [ -z "$version" ]; then
+      continue
+    fi
+
+    if [ "$version" != "$reference_version" ]; then
+      mismatches+=("$file has version $version (expected $reference_version)")
+    else
+      echo "✓ $file: $version"
+    fi
+  done
+
+  if [ ${#mismatches[@]} -gt 0 ]; then
+    echo ""
+    echo "ERROR: Version mismatches found:"
+    for mismatch in "${mismatches[@]}"; do
+      echo "  - $mismatch"
+    done
+    exit 1
+  fi
+
+  echo ""
+  echo "All package versions match: $reference_version"
+fi


### PR DESCRIPTION
## Summary

Switch from fixed versioning to independent versioning with lerna. This allows releasing packages individually without bumping all package versions together.

## Motivation

See discussion here: https://github.com/DataDog/openfeature-js-client/pull/287#discussion_r3277555489

This change enables a cleaner fix for the internal dependency pinning issue ([#283](https://github.com/DataDog/openfeature-js-client/pull/283)):

- Release `@datadog/openfeature-node-server@1.3.0` with pinned `flagging-core: "1.2.1"`
- Keep `@datadog/flagging-core` at 1.2.1 (no new release needed)
- Users on older dd-trace versions (v5.89-v5.102) with `^1.1.x` won't get a version mismatch

With fixed versioning, releasing any package bumps all packages, which would publish a new `flagging-core@1.3.0`. Users stuck on `openfeature-node-server@1.2.1` would receive it via their `^1.2.1` constraint—causing a mismatch between the openfeature package and its internal dependency.

**Note:** This is a temporary workaround. Any future changes to `flagging-core` will still require bumping it to `2.0.0`, since users on `openfeature-node-server@1.2.1` would pull new 1.x versions via the `^1.2.1` constraint.

## Changes

- **lerna.json**: `"version": "1.2.1"` → `"version": "independent"`
- **release.yaml**: Handle both independent (`@datadog/pkg@x.y.z`) and legacy unified (`vX.Y.Z`) release tags
- **versions-validate.sh**: Support independent versioning validation
- **scripts/cli**: Split release command into `yarn release` (changed packages only) and `yarn release:all` (all packages)
- **package.json**: Added `release:all` script
- **scripts/release/update-peer-dependency-versions.js**: Fixed to read versions from individual `package.json` files (was broken with `"version": "independent"`)
- **CONTRIBUTING.md**: Update docs with new release workflow steps

## Release Tag Format

We follow the same tagging convention as [emotion](https://github.com/emotion-js/emotion/tags):

| Format | Example | Behavior |
|--------|---------|----------|
| Independent | `@datadog/openfeature-node-server@1.3.0` | Publishes only that package |
| Unified (legacy) | `v1.2.1` | Publishes all packages (requires all versions match) |

## Testing

Validation logic tested locally - see PR comments for test results.