### PR TITLE
Release openfeature-browser and openfeature-node-server v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ---
 
+## v1.3.0
+
+**Bug Fixes:**
+
+- fix: pin @datadog/flagging-core to exact version to prevent version skew ([#292](https://github.com/DataDog/openfeature-js-client/pull/292)) [BROWSER] [NODE-SERVER]
+
+> **Note:** This is the first stable release with the serialId feature. v1.2.0 had yarn syntax issues, v1.2.1 had loose dependency issues.
+
 ## v1.2.0
 
 **Internal Changes:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,17 @@
 
 ---
 
-## v1.3.0
+## @datadog/openfeature-browser@1.3.0, @datadog/openfeature-node-server@1.3.0
 
 **Bug Fixes:**
 
 - fix: pin @datadog/flagging-core to exact version to prevent version skew ([#292](https://github.com/DataDog/openfeature-js-client/pull/292)) [BROWSER] [NODE-SERVER]
+
+**Internal Changes:**
+
+- chore: switch to lerna independent versioning ([#288](https://github.com/DataDog/openfeature-js-client/pull/288))
+- chore: pin exact versions for internal dependencies ([#283](https://github.com/DataDog/openfeature-js-client/pull/283))
+- ci: add npm compatibility smoke test ([#282](https://github.com/DataDog/openfeature-js-client/pull/282))
 
 > **Note:** This is the first stable release with the serialId feature. v1.2.0 had yarn syntax issues, v1.2.1 had loose dependency issues.
 

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@datadog/browser-core": "^6.33.0",
-    "@datadog/flagging-core": "^1.2.1"
+    "@datadog/flagging-core": "1.2.1"
   },
   "peerDependencies": {
     "@openfeature/core": "^1.9.2",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-browser",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Browser-specific bindings for OpenFeature (wraps @datadog/openfeature-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -36,7 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@datadog/flagging-core": "^1.2.1"
+    "@datadog/flagging-core": "1.2.1"
   },
   "peerDependencies": {
     "@openfeature/server-sdk": ">=1.15.1"

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-node-server",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Node.js server bindings for OpenFeature (wraps @datadog/flagging-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",

--- a/yarn.lock
+++ b/yarn.lock
@@ -659,7 +659,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/flagging-core@npm:^1.2.1, @datadog/flagging-core@workspace:packages/core":
+"@datadog/flagging-core@npm:1.2.1, @datadog/flagging-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@datadog/flagging-core@workspace:packages/core"
   dependencies:
@@ -681,7 +681,7 @@ __metadata:
   resolution: "@datadog/openfeature-browser@workspace:packages/browser"
   dependencies:
     "@datadog/browser-core": "npm:^6.33.0"
-    "@datadog/flagging-core": "npm:^1.2.1"
+    "@datadog/flagging-core": "npm:1.2.1"
     "@openfeature/core": "npm:^1.9.2"
     "@openfeature/web-sdk": "npm:^1.5.0"
     "@types/chrome": "npm:^0.1.18"
@@ -731,7 +731,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/openfeature-node-server@workspace:packages/node-server"
   dependencies:
-    "@datadog/flagging-core": "npm:^1.2.1"
+    "@datadog/flagging-core": "npm:1.2.1"
     "@openfeature/core": "npm:1.9.2"
     "@openfeature/server-sdk": "npm:1.20.2"
     "@types/jest": "npm:^30.0.0"


### PR DESCRIPTION
## Summary

Pin internal `@datadog/flagging-core` dependency to exact version `1.2.1` and bump `@datadog/openfeature-browser` and `@datadog/openfeature-node-server` to v1.3.0.

## Motivation

This is the first stable release with the serialId feature:
- **1.2.0**: Broken due to yarn syntax issues
- **1.2.1**: Introduced loose dependencies (`^1.2.1`) which prevents safely releasing updates to flagging-core
- **1.3.0**: First stable release with exact dependency pinning

## Changes

- `packages/browser/package.json`: Pin `@datadog/flagging-core` to `1.2.1`, bump version to `1.3.0`
- `packages/node-server/package.json`: Pin `@datadog/flagging-core` to `1.2.1`, bump version to `1.3.0`
- `yarn.lock`: Updated to reflect exact versions
- `CHANGELOG.md`: Added v1.3.0 entry

## Next Steps

After merge, create GitHub releases for:
- `@datadog/openfeature-browser@1.3.0`
- `@datadog/openfeature-node-server@1.3.0`