### PR TITLE
Holdout prototype/demo

### DIFF
--- a/packages/browser/src/evaluation.ts
+++ b/packages/browser/src/evaluation.ts
@@ -54,7 +54,10 @@ function evaluatePrecomputed<T extends FlagValueType>(
       allocationKey: flag.allocationKey,
       variationType: flag.variationType,
       doLog: flag.doLog,
-      ...holdoutMetadataFromExtraLogging(flag.extraLogging),
+      ...(flag.holdout && {
+        __dd_holdout_key: flag.holdout.key,
+        __dd_holdout_variation: flag.holdout.variation,
+      }),
     } as PrecomputedFlagMetadata,
     reason: flag.reason,
   } as ResolutionDetails<FlagTypeToValue<T>>
@@ -77,21 +80,4 @@ function variationTypeToOpenFeature(s: string): FlagValueType {
   }
 
   return typeMap[s] || s.toLowerCase()
-}
-
-function holdoutMetadataFromExtraLogging(extraLogging?: Record<string, unknown>): Partial<PrecomputedFlagMetadata> {
-  if (!extraLogging) {
-    return {}
-  }
-
-  return {
-    __dd_holdout_key: stringValue(extraLogging.holdoutKey),
-    __dd_holdout_experiment_id: stringValue(extraLogging.holdoutAnalysisExperimentId),
-    __dd_holdout_variation: stringValue(extraLogging.holdoutVariation),
-    __dd_holdout_base_allocation_key: stringValue(extraLogging.holdoutBaseAllocationKey),
-  }
-}
-
-function stringValue(value: unknown): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined
 }

--- a/packages/browser/src/evaluation.ts
+++ b/packages/browser/src/evaluation.ts
@@ -54,6 +54,7 @@ function evaluatePrecomputed<T extends FlagValueType>(
       allocationKey: flag.allocationKey,
       variationType: flag.variationType,
       doLog: flag.doLog,
+      ...holdoutMetadataFromExtraLogging(flag.extraLogging),
     } as PrecomputedFlagMetadata,
     reason: flag.reason,
   } as ResolutionDetails<FlagTypeToValue<T>>
@@ -76,4 +77,21 @@ function variationTypeToOpenFeature(s: string): FlagValueType {
   }
 
   return typeMap[s] || s.toLowerCase()
+}
+
+function holdoutMetadataFromExtraLogging(extraLogging?: Record<string, unknown>): Partial<PrecomputedFlagMetadata> {
+  if (!extraLogging) {
+    return {}
+  }
+
+  return {
+    __dd_holdout_key: stringValue(extraLogging.holdoutKey),
+    __dd_holdout_experiment_id: stringValue(extraLogging.holdoutAnalysisExperimentId),
+    __dd_holdout_variation: stringValue(extraLogging.holdoutVariation),
+    __dd_holdout_base_allocation_key: stringValue(extraLogging.holdoutBaseAllocationKey),
+  }
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
 }

--- a/packages/browser/test/evaluation.spec.ts
+++ b/packages/browser/test/evaluation.spec.ts
@@ -67,4 +67,48 @@ describe('evaluate', () => {
       },
     })
   })
+
+  it('passes holdout extraLogging through precomputed flag metadata', () => {
+    const result = evaluate(
+      {
+        precomputed: {
+          response: {
+            data: {
+              attributes: {
+                createdAt: '2026-06-02T00:00:00.000Z',
+                flags: {
+                  'checkout-redesign': {
+                    allocationKey: 'allocation-a-holdout-q2-global-holdout',
+                    variationKey: 'control',
+                    variationType: 'boolean',
+                    variationValue: false,
+                    reason: 'TARGETING_MATCH',
+                    doLog: true,
+                    extraLogging: {
+                      holdoutKey: 'q2-global-holdout',
+                      holdoutAnalysisExperimentId: 'holdout-analysis-experiment-id',
+                      holdoutVariation: 'status_quo',
+                      holdoutBaseAllocationKey: 'allocation-a',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      'boolean',
+      'checkout-redesign',
+      true,
+      {}
+    )
+
+    expect(result.flagMetadata).toMatchObject({
+      allocationKey: 'allocation-a-holdout-q2-global-holdout',
+      __dd_holdout_key: 'q2-global-holdout',
+      __dd_holdout_experiment_id: 'holdout-analysis-experiment-id',
+      __dd_holdout_variation: 'status_quo',
+      __dd_holdout_base_allocation_key: 'allocation-a',
+    })
+  })
 })

--- a/packages/browser/test/evaluation.spec.ts
+++ b/packages/browser/test/evaluation.spec.ts
@@ -68,7 +68,7 @@ describe('evaluate', () => {
     })
   })
 
-  it('passes holdout extraLogging through precomputed flag metadata', () => {
+  it('passes holdout metadata through precomputed flag metadata', () => {
     const result = evaluate(
       {
         precomputed: {
@@ -84,11 +84,10 @@ describe('evaluate', () => {
                     variationValue: false,
                     reason: 'TARGETING_MATCH',
                     doLog: true,
-                    extraLogging: {
-                      holdoutKey: 'q2-global-holdout',
-                      holdoutAnalysisExperimentId: 'holdout-analysis-experiment-id',
-                      holdoutVariation: 'status_quo',
-                      holdoutBaseAllocationKey: 'allocation-a',
+                    extraLogging: {},
+                    holdout: {
+                      key: 'q2-global-holdout',
+                      variation: 'status_quo',
                     },
                   },
                 },
@@ -106,9 +105,7 @@ describe('evaluate', () => {
     expect(result.flagMetadata).toMatchObject({
       allocationKey: 'allocation-a-holdout-q2-global-holdout',
       __dd_holdout_key: 'q2-global-holdout',
-      __dd_holdout_experiment_id: 'holdout-analysis-experiment-id',
       __dd_holdout_variation: 'status_quo',
-      __dd_holdout_base_allocation_key: 'allocation-a',
     })
   })
 })

--- a/packages/core/src/configuration/configuration.ts
+++ b/packages/core/src/configuration/configuration.ts
@@ -58,10 +58,36 @@ export type PrecomputedFlagMetadata = {
   variationType: FlagValueType
   doLog: boolean
 
+  // Holdout metadata copied from UFC split.extraLogging
+  __dd_holdout_key?: string
+  __dd_holdout_experiment_id?: string
+  __dd_holdout_variation?: string
+  __dd_holdout_base_allocation_key?: string
+
   // Server-side tracing keys (consumed by dd-trace-js)
   __dd_allocation_key?: string
   __dd_do_log?: boolean
   __dd_split_serial_id?: number
+}
+
+/** @internal */
+export function holdoutMetadataFromExtraLogging(
+  extraLogging?: Record<string, unknown>
+): Partial<PrecomputedFlagMetadata> {
+  if (!extraLogging) {
+    return {}
+  }
+
+  return {
+    __dd_holdout_key: stringValue(extraLogging.holdoutKey),
+    __dd_holdout_experiment_id: stringValue(extraLogging.holdoutAnalysisExperimentId),
+    __dd_holdout_variation: stringValue(extraLogging.holdoutVariation),
+    __dd_holdout_base_allocation_key: stringValue(extraLogging.holdoutBaseAllocationKey),
+  }
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
 }
 
 /**

--- a/packages/core/src/configuration/configuration.ts
+++ b/packages/core/src/configuration/configuration.ts
@@ -41,6 +41,12 @@ export type PrecomputedConfigurationResponse = {
 }
 
 /** @internal */
+export type HoldoutMetadata = {
+  key: string
+  variation: string
+}
+
+/** @internal */
 export type PrecomputedFlag<T extends FlagValueType = FlagValueType> = {
   allocationKey: string
   variationKey: string
@@ -49,6 +55,7 @@ export type PrecomputedFlag<T extends FlagValueType = FlagValueType> = {
   reason: ResolutionReason
   doLog: boolean
   extraLogging: Record<string, unknown>
+  holdout?: HoldoutMetadata
 }
 
 /** @internal */
@@ -58,36 +65,14 @@ export type PrecomputedFlagMetadata = {
   variationType: FlagValueType
   doLog: boolean
 
-  // Holdout metadata copied from UFC split.extraLogging
+  // Holdout metadata from UFC split.holdout (first-class field)
   __dd_holdout_key?: string
-  __dd_holdout_experiment_id?: string
   __dd_holdout_variation?: string
-  __dd_holdout_base_allocation_key?: string
 
   // Server-side tracing keys (consumed by dd-trace-js)
   __dd_allocation_key?: string
   __dd_do_log?: boolean
   __dd_split_serial_id?: number
-}
-
-/** @internal */
-export function holdoutMetadataFromExtraLogging(
-  extraLogging?: Record<string, unknown>
-): Partial<PrecomputedFlagMetadata> {
-  if (!extraLogging) {
-    return {}
-  }
-
-  return {
-    __dd_holdout_key: stringValue(extraLogging.holdoutKey),
-    __dd_holdout_experiment_id: stringValue(extraLogging.holdoutAnalysisExperimentId),
-    __dd_holdout_variation: stringValue(extraLogging.holdoutVariation),
-    __dd_holdout_base_allocation_key: stringValue(extraLogging.holdoutBaseAllocationKey),
-  }
-}
-
-function stringValue(value: unknown): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined
 }
 
 /**

--- a/packages/core/src/configuration/exposureEvent.ts
+++ b/packages/core/src/configuration/exposureEvent.ts
@@ -18,6 +18,8 @@ export function createExposureEvent<T extends FlagValue>(
   }
 
   const { targetingKey: id = '', ...attributes } = context
+  const holdoutKey = details.flagMetadata?.__dd_holdout_key as string | undefined
+  const holdoutVariation = details.flagMetadata?.__dd_holdout_variation as string | undefined
 
   return {
     allocation: {
@@ -33,5 +35,14 @@ export function createExposureEvent<T extends FlagValue>(
       id,
       attributes,
     },
+    ...(holdoutKey &&
+      holdoutVariation && {
+        holdout: {
+          key: holdoutKey,
+          experiment_id: details.flagMetadata?.__dd_holdout_experiment_id as string | undefined,
+          variation: holdoutVariation,
+          base_allocation_key: details.flagMetadata?.__dd_holdout_base_allocation_key as string | undefined,
+        },
+      }),
   } satisfies ExposureEvent
 }

--- a/packages/core/src/configuration/exposureEvent.ts
+++ b/packages/core/src/configuration/exposureEvent.ts
@@ -21,6 +21,7 @@ export function createExposureEvent<T extends FlagValue>(
   const holdoutKey = details.flagMetadata?.__dd_holdout_key as string | undefined
   const holdoutVariation = details.flagMetadata?.__dd_holdout_variation as string | undefined
 
+
   return {
     allocation: {
       key: allocationKey,
@@ -39,9 +40,7 @@ export function createExposureEvent<T extends FlagValue>(
       holdoutVariation && {
         holdout: {
           key: holdoutKey,
-          experiment_id: details.flagMetadata?.__dd_holdout_experiment_id as string | undefined,
           variation: holdoutVariation,
-          base_allocation_key: details.flagMetadata?.__dd_holdout_base_allocation_key as string | undefined,
         },
       }),
   } satisfies ExposureEvent

--- a/packages/core/src/configuration/exposureEvent.types.ts
+++ b/packages/core/src/configuration/exposureEvent.types.ts
@@ -16,9 +16,7 @@ export interface ExposureEvent {
   }
   holdout?: {
     key: string
-    experiment_id?: string
     variation: string
-    base_allocation_key?: string
   }
   service?: string
   rum?: {

--- a/packages/core/src/configuration/exposureEvent.types.ts
+++ b/packages/core/src/configuration/exposureEvent.types.ts
@@ -14,6 +14,12 @@ export interface ExposureEvent {
     id: string
     attributes: EvaluationContext
   }
+  holdout?: {
+    key: string
+    experiment_id?: string
+    variation: string
+    base_allocation_key?: string
+  }
   service?: string
   rum?: {
     application?: {

--- a/packages/core/test/configuration/exposureEvent.spec.ts
+++ b/packages/core/test/configuration/exposureEvent.spec.ts
@@ -1,0 +1,43 @@
+import { createExposureEvent } from '../../src/configuration/exposureEvent'
+
+describe('createExposureEvent', () => {
+  it('includes holdout metadata from flag metadata on exposure events', () => {
+    const event = createExposureEvent(
+      {
+        targetingKey: 'user-123',
+        plan: 'pro',
+      },
+      {
+        flagKey: 'checkout-redesign',
+        value: false,
+        variant: 'control',
+        reason: 'TARGETING_MATCH',
+        flagMetadata: {
+          allocationKey: 'allocation-a-holdout-q2-global-holdout',
+          variationType: 'boolean',
+          doLog: true,
+          __dd_holdout_key: 'q2-global-holdout',
+          __dd_holdout_experiment_id: 'holdout-analysis-experiment-id',
+          __dd_holdout_variation: 'status_quo',
+          __dd_holdout_base_allocation_key: 'allocation-a',
+        },
+      }
+    )
+
+    expect(event).toMatchObject({
+      allocation: { key: 'allocation-a-holdout-q2-global-holdout' },
+      flag: { key: 'checkout-redesign' },
+      variant: { key: 'control' },
+      subject: {
+        id: 'user-123',
+        attributes: { plan: 'pro' },
+      },
+      holdout: {
+        key: 'q2-global-holdout',
+        experiment_id: 'holdout-analysis-experiment-id',
+        variation: 'status_quo',
+        base_allocation_key: 'allocation-a',
+      },
+    })
+  })
+})

--- a/packages/core/test/configuration/exposureEvent.spec.ts
+++ b/packages/core/test/configuration/exposureEvent.spec.ts
@@ -17,9 +17,7 @@ describe('createExposureEvent', () => {
           variationType: 'boolean',
           doLog: true,
           __dd_holdout_key: 'q2-global-holdout',
-          __dd_holdout_experiment_id: 'holdout-analysis-experiment-id',
           __dd_holdout_variation: 'status_quo',
-          __dd_holdout_base_allocation_key: 'allocation-a',
         },
       }
     )
@@ -34,9 +32,7 @@ describe('createExposureEvent', () => {
       },
       holdout: {
         key: 'q2-global-holdout',
-        experiment_id: 'holdout-analysis-experiment-id',
         variation: 'status_quo',
-        base_allocation_key: 'allocation-a',
       },
     })
   })

--- a/packages/node-server/src/configuration/evaluateForSubject.ts
+++ b/packages/node-server/src/configuration/evaluateForSubject.ts
@@ -96,6 +96,7 @@ export function evaluateForSubject<T extends FlagValueType>(
             allocationKey: allocation.key,
             variationType: variantTypeToFlagValueType(flag.variationType),
             doLog: !!allocation.doLog,
+            ...holdoutMetadataFromExtraLogging(selectedSplit.extraLogging),
           } as PrecomputedFlagMetadata,
         }
       }
@@ -134,6 +135,19 @@ function validateTypeMatch(expectedType: FlagValueType, variantType: VariantType
     return variantType === 'JSON'
   }
   throw new Error(`Invalid expected type: ${expectedType}`)
+}
+
+function holdoutMetadataFromExtraLogging(extraLogging?: Record<string, string>): Partial<PrecomputedFlagMetadata> {
+  if (!extraLogging) {
+    return {}
+  }
+
+  return {
+    __dd_holdout_key: extraLogging.holdoutKey,
+    __dd_holdout_experiment_id: extraLogging.holdoutAnalysisExperimentId,
+    __dd_holdout_variation: extraLogging.holdoutVariation,
+    __dd_holdout_base_allocation_key: extraLogging.holdoutBaseAllocationKey,
+  }
 }
 
 export function containsMatchingRule(

--- a/packages/node-server/test/evaluateForSubject.spec.ts
+++ b/packages/node-server/test/evaluateForSubject.spec.ts
@@ -15,6 +15,52 @@ describe('evaluateForSubject', () => {
   })
 
   describe('__dd_split_serial_id passthrough', () => {
+    it('should pass through holdout extraLogging to flagMetadata', () => {
+      const flag: Flag = {
+        key: 'checkout-redesign',
+        enabled: true,
+        variationType: 'BOOLEAN',
+        variations: {
+          control: { key: 'control', value: false },
+        },
+        allocations: [
+          {
+            key: 'allocation-a-holdout-q2-global-holdout',
+            doLog: true,
+            splits: [
+              {
+                variationKey: 'control',
+                extraLogging: {
+                  holdoutKey: 'q2-global-holdout',
+                  holdoutAnalysisExperimentId: 'holdout-analysis-experiment-id',
+                  holdoutVariation: 'status_quo',
+                  holdoutBaseAllocationKey: 'allocation-a',
+                },
+                shards: [
+                  {
+                    salt: 'holdout-salt',
+                    ranges: [{ start: 0, end: 10000 }],
+                    totalShards: 10000,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }
+
+      const result = evaluateForSubject(flag, 'boolean', 'user-123', { id: 'user-123' }, true, logger)
+
+      expect(result.value).toBe(false)
+      expect(result.flagMetadata).toMatchObject({
+        allocationKey: 'allocation-a-holdout-q2-global-holdout',
+        __dd_holdout_key: 'q2-global-holdout',
+        __dd_holdout_experiment_id: 'holdout-analysis-experiment-id',
+        __dd_holdout_variation: 'status_quo',
+        __dd_holdout_base_allocation_key: 'allocation-a',
+      })
+    })
+
     it('should pass through serialId from split to flagMetadata.__dd_split_serial_id', () => {
       const serialId = 12345
       const flag: Flag = {


### PR DESCRIPTION
## Prototype/demo only

This is a draft PR for visualizing the SDK-side holdout exposure metadata changes. It is **not intended to merge** as-is.

## What changed

- Pass holdout metadata from UFC `split.extraLogging` into OpenFeature `flagMetadata`.
- Include a `holdout` object on exposure events when holdout metadata is present.
- Cover both node-server UFC evaluation and browser precomputed evaluation paths.
- Add targeted tests showing metadata propagation into exposure events.

## Validation

- `yarn workspace @datadog/flagging-core test test/configuration/exposureEvent.spec.ts --runInBand --watchman=false`
- `yarn workspace @datadog/openfeature-node-server test test/evaluateForSubject.spec.ts --runInBand --watchman=false`
- `yarn workspace @datadog/openfeature-browser test test/evaluation.spec.ts --runInBand --watchman=false`
- `yarn workspace @datadog/flagging-core typecheck`
- `yarn workspace @datadog/openfeature-node-server typecheck`
- `yarn workspace @datadog/openfeature-browser typecheck`
- `yarn prettier --check <touched files>`