### PR TITLE
refactor(browser): migrate dateNow from browser-core to js-core

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -57,6 +57,7 @@
 "@csstools/css-tokenizer","@csstools/css-tokenizer","['MIT']","['Antonio Laguna <antonio@laguna.es>', 'Romain Menke']"
 "@datadog/browser-core","@datadog/browser-core","['Apache-2.0']","['Datadog, Inc.']"
 "@datadog/flagging-core","@datadog/flagging-core","['Apache-2.0']","['Datadog, Inc.']"
+"@datadog/js-core","@datadog/js-core","['Apache-2.0']","['Datadog, Inc.']"
 "@emnapi/core","@emnapi/core","['MIT']","['Microsoft Corporation', 'Toyobayashi']"
 "@emnapi/runtime","@emnapi/runtime","['MIT']","['Microsoft Corporation', 'Toyobayashi']"
 "@emnapi/wasi-threads","@emnapi/wasi-threads","['MIT']","['Toyobayashi']"

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -45,7 +45,8 @@
   },
   "dependencies": {
     "@datadog/browser-core": "^6.33.0",
-    "@datadog/flagging-core": "1.2.1"
+    "@datadog/flagging-core": "1.2.1",
+    "@datadog/js-core": "0.0.1"
   },
   "peerDependencies": {
     "@openfeature/core": "^1.9.2",

--- a/packages/browser/src/openfeature/exposures.ts
+++ b/packages/browser/src/openfeature/exposures.ts
@@ -1,5 +1,6 @@
 import type { Context, RawError } from '@datadog/browser-core'
-import { addTelemetryDebug, createPageMayExitObservable, dateNow } from '@datadog/browser-core'
+import { addTelemetryDebug, createPageMayExitObservable } from '@datadog/browser-core'
+import { dateNow } from '@datadog/js-core/time'
 import { type AssignmentCache, createExposureEvent, type ExposureEventWithTimestamp } from '@datadog/flagging-core'
 import type { EvaluationDetails, FlagValue, Hook, HookContext } from '@openfeature/web-sdk'
 import type { FlaggingConfiguration } from '../domain/configuration'

--- a/packages/browser/src/openfeature/exposures.ts
+++ b/packages/browser/src/openfeature/exposures.ts
@@ -1,7 +1,7 @@
 import type { Context, RawError } from '@datadog/browser-core'
 import { addTelemetryDebug, createPageMayExitObservable } from '@datadog/browser-core'
-import { dateNow } from '@datadog/js-core/time'
 import { type AssignmentCache, createExposureEvent, type ExposureEventWithTimestamp } from '@datadog/flagging-core'
+import { dateNow } from '@datadog/js-core/time'
 import type { EvaluationDetails, FlagValue, Hook, HookContext } from '@openfeature/web-sdk'
 import type { FlaggingConfiguration } from '../domain/configuration'
 import { startExposuresBatch } from '../transport/startExposuresBatch'

--- a/packages/browser/src/transport/fetchConfiguration.ts
+++ b/packages/browser/src/transport/fetchConfiguration.ts
@@ -1,4 +1,4 @@
-import { dateNow } from '@datadog/browser-core'
+import { dateNow } from '@datadog/js-core/time'
 import type { FlagsConfiguration } from '@datadog/flagging-core'
 import type { EvaluationContext } from '@openfeature/web-sdk'
 import type { FlaggingInitConfiguration } from '../domain/configuration'

--- a/packages/browser/src/transport/fetchConfiguration.ts
+++ b/packages/browser/src/transport/fetchConfiguration.ts
@@ -1,5 +1,5 @@
-import { dateNow } from '@datadog/js-core/time'
 import type { FlagsConfiguration } from '@datadog/flagging-core'
+import { dateNow } from '@datadog/js-core/time'
 import type { EvaluationContext } from '@openfeature/web-sdk'
 import type { FlaggingInitConfiguration } from '../domain/configuration'
 import { buildEndpointHost } from './endpoint'

--- a/packages/browser/test/transport/fetchConfiguration.spec.ts
+++ b/packages/browser/test/transport/fetchConfiguration.spec.ts
@@ -2,8 +2,7 @@ import type { EvaluationContext } from '@openfeature/web-sdk'
 import type { FlaggingInitConfiguration } from '../../src/domain/configuration'
 import { createFlagsConfigurationFetcher } from '../../src/transport/fetchConfiguration'
 
-// Mock dateNow from @datadog/browser-core
-jest.mock('@datadog/browser-core', () => ({
+jest.mock('@datadog/js-core/time', () => ({
   dateNow: jest.fn(() => 1234567890),
 }))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,12 +676,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@datadog/js-core@npm:0.0.1":
+  version: 0.0.1
+  resolution: "@datadog/js-core@npm:0.0.1"
+  checksum: 10c0/68d0a421f867cac67b6f785da526ddeb7e7d712b014b379b23533a67e6d43fba464a721e15b0ed623c0048a629edd624ed7d5eceedb6ebf2e293bf982adcd92e
+  languageName: node
+  linkType: hard
+
 "@datadog/openfeature-browser@workspace:packages/browser":
   version: 0.0.0-use.local
   resolution: "@datadog/openfeature-browser@workspace:packages/browser"
   dependencies:
     "@datadog/browser-core": "npm:^6.33.0"
     "@datadog/flagging-core": "npm:1.2.1"
+    "@datadog/js-core": "npm:0.0.1"
     "@openfeature/core": "npm:^1.9.2"
     "@openfeature/web-sdk": "npm:^1.5.0"
     "@types/chrome": "npm:^0.1.18"


### PR DESCRIPTION
## Motivation

`@datadog/js-core` has been published as a new shared utility package. `dateNow` is now available from `@datadog/js-core/time`, so we can stop pulling it from the browser-specific `@datadog/browser-core`.

## Changes

- `packages/browser/package.json`: add `@datadog/js-core@0.0.1` as a dependency
- `exposures.ts` / `fetchConfiguration.ts`: import `dateNow` from `@datadog/js-core/time` instead of `@datadog/browser-core`
- `fetchConfiguration.spec.ts`: update Jest mock path to match the new import source

## Test instructions

```bash
cd packages/browser
yarn typecheck
yarn test
```

## Checklist

- [ ] Updated Documentation
- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.