### PR TITLE
feat(browser): support uk1.datadoghq.com site

### DIFF
--- a/packages/browser/src/transport/endpoint.ts
+++ b/packages/browser/src/transport/endpoint.ts
@@ -5,6 +5,7 @@ const siteConfig: Record<string, { dc?: string; tld?: string }> = {
   'us5.datadoghq.com': { dc: 'us5' },
   'ap1.datadoghq.com': { dc: 'ap1' },
   'ap2.datadoghq.com': { dc: 'ap2' },
+  'uk1.datadoghq.com': { dc: 'uk1' },
   'datadoghq.eu': { tld: 'eu' },
 }
 

--- a/packages/browser/test/transport/endpoint.spec.ts
+++ b/packages/browser/test/transport/endpoint.spec.ts
@@ -29,6 +29,11 @@ describe('buildEndpointHost', () => {
         expected: 'preview.ff-cdn.ap2.datadoghq.com',
       },
       {
+        description: 'for uk1.datadoghq.com site',
+        site: 'uk1.datadoghq.com',
+        expected: 'preview.ff-cdn.uk1.datadoghq.com',
+      },
+      {
         description: 'for datadoghq.eu site',
         site: 'datadoghq.eu',
         expected: 'preview.ff-cdn.datadoghq.eu',
@@ -91,13 +96,13 @@ describe('buildEndpointHost', () => {
         description: 'for unsupported site',
         site: 'unsupported.example.com',
         expectedError:
-          'Unsupported site: unsupported.example.com. Supported sites: datadoghq.com, us3.datadoghq.com, us5.datadoghq.com, ap1.datadoghq.com, ap2.datadoghq.com, datadoghq.eu',
+          'Unsupported site: unsupported.example.com. Supported sites: datadoghq.com, us3.datadoghq.com, us5.datadoghq.com, ap1.datadoghq.com, ap2.datadoghq.com, uk1.datadoghq.com, datadoghq.eu',
       },
       {
         description: 'for empty string site',
         site: '',
         expectedError:
-          'Unsupported site: . Supported sites: datadoghq.com, us3.datadoghq.com, us5.datadoghq.com, ap1.datadoghq.com, ap2.datadoghq.com, datadoghq.eu',
+          'Unsupported site: . Supported sites: datadoghq.com, us3.datadoghq.com, us5.datadoghq.com, ap1.datadoghq.com, ap2.datadoghq.com, uk1.datadoghq.com, datadoghq.eu',
       },
     ]
 


### PR DESCRIPTION
## Motivation

Customers on the `uk1` datacenter (`uk1.datadoghq.com`) cannot initialize the flagging endpoint — `buildEndpointHost` throws `Unsupported site: uk1.datadoghq.com` because `uk1` is missing from the hardcoded `siteConfig` map. This surfaced from a real session on the `uk1.prod.dog` datacenter.

## Changes

- Add `'uk1.datadoghq.com': { dc: 'uk1' }` to `siteConfig` in `packages/browser/src/transport/endpoint.ts`. `buildEndpointHost('uk1.datadoghq.com')` now returns `preview.ff-cdn.uk1.datadoghq.com` instead of throwing.
- Add a `uk1` success case to the endpoint test suite and update the two "Supported sites" error-message assertions (the message is derived from `Object.keys(siteConfig)`).

This is a backward-compatible change scoped entirely to the browser package; `flagging-core` and `node-server` are untouched.

## Test instructions

```bash
yarn lerna run test --scope=@datadog/openfeature-browser --stream
```

All 17 `buildEndpointHost` tests pass. Lint (biome), format (prettier), and typecheck also pass locally.

## Checklist

- [ ] Updated Documentation
- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.