### PR TITLE
Release openfeature-browser@1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 ---
 
+## @datadog/openfeature-browser@1.2.3
+
+**Features:**
+
+- feat(browser): support uk1.datadoghq.com site ([#309](https://github.com/DataDog/openfeature-js-client/pull/309))
+
+**Internal Changes:**
+
+- refactor(browser): migrate dateNow from browser-core to js-core ([#300](https://github.com/DataDog/openfeature-js-client/pull/300))
+
 ## @datadog/openfeature-browser@1.2.2, @datadog/openfeature-node-server@2.0.0
 
 **Bug Fixes:**

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-browser",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Browser-specific bindings for OpenFeature (wraps @datadog/openfeature-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",


### PR DESCRIPTION
## Motivation

Release **`@datadog/openfeature-browser@1.2.3`**. This is the first release shipping `uk1.datadoghq.com` site support (#309), unblocking customers on the `uk1` datacenter who currently hit `Unsupported site`. It also ships the `dateNow` → `@datadog/js-core` migration (#300) that landed since `1.2.2`.

## Changes

- Bump `@datadog/openfeature-browser` `1.2.2` → `1.2.3` (`packages/browser/package.json`).
- Add CHANGELOG entry covering #309 (Features) and #300 (Internal Changes).

Browser-only release — `flagging-core` and `node-server` are unchanged.

> **Note on the manual bump:** the version was bumped manually rather than via `yarn release`. Lerna's change detection fell back to the old unified `v1.2.1` tag because the previous release's per-package tags (`@datadog/openfeature-browser@1.2.2`, `@datadog/openfeature-node-server@2.0.0`) are unreachable from `main` — they point at the pre-squash-merge commit of #293. As a result Lerna wanted to release `node-server` too (a false positive). The manual bump produces the identical artifacts (version commit + `@datadog/openfeature-browser@1.2.3` tag) without a spurious node-server release. Follow-up: consider merge-commits (not squash) for release PRs so version tags stay reachable.

## Test instructions

- CI validates lint, format, build, and tests on this branch.
- Internal-deps exact-version validation passes locally (`bash scripts/internal-deps-validate.sh`).
- Publishing happens after merge by creating a GitHub Release on the existing **`@datadog/openfeature-browser@1.2.3`** tag, which triggers `release.yaml` to `npm publish` the browser package with the `latest` tag.

## Checklist

- [ ] Updated Documentation
- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.