### PR TITLE
docs: require merge-commit for release PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,13 @@ All packages are published with the `latest` npm tag.
    - Same as above, but uses `--force-publish` to prompt for **all** packages
    - Use this when you want to release all packages together with the same version
 
-#### Step 4: Publish via GitHub Release
+#### Step 4: Open and Merge the Release PR
+
+4. **Open a PR from your release branch and merge it with a merge commit — not a squash.**
+
+   `yarn release` pushes the version tag onto your branch commit. Squashing creates a new commit on `main` and orphans that tag, which breaks change detection on the _next_ release (Lerna falls back to an old tag and prompts to version packages that never changed). A merge commit keeps the tag reachable.
+
+#### Step 5: Publish via GitHub Release
 
 **Publishing is fully automated via GitHub workflows!**
 


### PR DESCRIPTION
## Motivation

While releasing `openfeature-browser@1.2.3`, `yarn release` falsely prompted to version `node-server` too. Root cause: the previous release PR was squash-merged, which orphaned its per-package tags (they point at the pre-squash commit, unreachable from `main`). Lerna's change detection then fell back to the old `v1.2.1` tag and flagged every package bumped since.

## Changes

- Add **Step 4: Open and Merge the Release PR** to the release process, documenting that release PRs must be merged with a **merge commit, not a squash**, so the tags `yarn release` pushes stay reachable from `main`.
- Renumber the publish step to Step 5.

Pairs with the repo setting change to allow merge commits.

## Test instructions

Docs-only. `prettier --check CONTRIBUTING.md` passes.

## Checklist

- [x] Updated Documentation
- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.