### PR TITLE
Align Node.js flagevaluation EVP metadata

### DIFF
--- a/packages/browser/src/openfeature/flagEvaluations.ts
+++ b/packages/browser/src/openfeature/flagEvaluations.ts
@@ -12,7 +12,7 @@ import { FlagEvaluationAggregator, type FlagEvaluationEvent } from '@datadog/fla
 import type { EvaluationDetails, FlagValue, Hook, HookContext } from '@openfeature/web-sdk'
 import type { FlaggingConfiguration } from '../domain/configuration'
 
-export function createFlagEvalEVPHook(configuration: FlaggingConfiguration): Hook {
+export function createFlagEvalLoggingHook(configuration: FlaggingConfiguration): Hook {
   const pageMayExitObservable = createPageMayExitObservable(configuration)
   const flagEvaluationBatch = createBatch({
     encoder: createIdentityEncoder(),

--- a/packages/browser/src/openfeature/flagEvaluations.ts
+++ b/packages/browser/src/openfeature/flagEvaluations.ts
@@ -12,7 +12,7 @@ import { FlagEvaluationAggregator, type FlagEvaluationEvent } from '@datadog/fla
 import type { EvaluationDetails, FlagValue, Hook, HookContext } from '@openfeature/web-sdk'
 import type { FlaggingConfiguration } from '../domain/configuration'
 
-export function createFlagEvaluationTrackingHook(configuration: FlaggingConfiguration): Hook {
+export function createFlagEvalEVPHook(configuration: FlaggingConfiguration): Hook {
   const pageMayExitObservable = createPageMayExitObservable(configuration)
   const flagEvaluationBatch = createBatch({
     encoder: createIdentityEncoder(),

--- a/packages/browser/src/openfeature/flagEvaluations.ts
+++ b/packages/browser/src/openfeature/flagEvaluations.ts
@@ -12,7 +12,7 @@ import { FlagEvaluationAggregator, type FlagEvaluationEvent } from '@datadog/fla
 import type { EvaluationDetails, FlagValue, Hook, HookContext } from '@openfeature/web-sdk'
 import type { FlaggingConfiguration } from '../domain/configuration'
 
-export function createFlagEvalLoggingHook(configuration: FlaggingConfiguration): Hook {
+export function createFlagEvalEVPHook(configuration: FlaggingConfiguration): Hook {
   const pageMayExitObservable = createPageMayExitObservable(configuration)
   const flagEvaluationBatch = createBatch({
     encoder: createIdentityEncoder(),

--- a/packages/browser/src/openfeature/provider.ts
+++ b/packages/browser/src/openfeature/provider.ts
@@ -25,7 +25,7 @@ import {
 } from '../domain/configuration'
 import { evaluate } from '../evaluation'
 import { createExposureLoggingHook } from './exposures'
-import { createFlagEvaluationTrackingHook } from './flagEvaluations'
+import { createFlagEvalEVPHook } from './flagEvaluations'
 import { createRumTrackingHook } from './rumIntegration'
 
 /**
@@ -103,10 +103,10 @@ export class DatadogProvider implements Provider {
       this.hooks.push(createRumTrackingHook())
     }
 
-    // Add flag evaluation tracking hook
+    // Add EVP flag evaluation hook.
     const isEvaluationTrackingEnabled = options.enableFlagEvaluationTracking ?? true
     if (isEvaluationTrackingEnabled && this.configuration) {
-      this.hooks.push(createFlagEvaluationTrackingHook(this.configuration))
+      this.hooks.push(createFlagEvalEVPHook(this.configuration))
     }
 
     // Add proper exposure logging hook (creates batch internally)

--- a/packages/browser/src/openfeature/provider.ts
+++ b/packages/browser/src/openfeature/provider.ts
@@ -25,7 +25,7 @@ import {
 } from '../domain/configuration'
 import { evaluate } from '../evaluation'
 import { createExposureLoggingHook } from './exposures'
-import { createFlagEvalLoggingHook } from './flagEvaluations'
+import { createFlagEvalEVPHook } from './flagEvaluations'
 import { createRumTrackingHook } from './rumIntegration'
 
 /**
@@ -106,7 +106,7 @@ export class DatadogProvider implements Provider {
     // Add EVP flag evaluation hook.
     const isEvaluationTrackingEnabled = options.enableFlagEvaluationTracking ?? true
     if (isEvaluationTrackingEnabled && this.configuration) {
-      this.hooks.push(createFlagEvalLoggingHook(this.configuration))
+      this.hooks.push(createFlagEvalEVPHook(this.configuration))
     }
 
     // Add proper exposure logging hook (creates batch internally)

--- a/packages/browser/src/openfeature/provider.ts
+++ b/packages/browser/src/openfeature/provider.ts
@@ -25,7 +25,7 @@ import {
 } from '../domain/configuration'
 import { evaluate } from '../evaluation'
 import { createExposureLoggingHook } from './exposures'
-import { createFlagEvalEVPHook } from './flagEvaluations'
+import { createFlagEvalLoggingHook } from './flagEvaluations'
 import { createRumTrackingHook } from './rumIntegration'
 
 /**
@@ -103,10 +103,10 @@ export class DatadogProvider implements Provider {
       this.hooks.push(createRumTrackingHook())
     }
 
-    // Add EVP flag evaluation hook.
+    // Add flag evaluation logging hook.
     const isEvaluationTrackingEnabled = options.enableFlagEvaluationTracking ?? true
     if (isEvaluationTrackingEnabled && this.configuration) {
-      this.hooks.push(createFlagEvalEVPHook(this.configuration))
+      this.hooks.push(createFlagEvalLoggingHook(this.configuration))
     }
 
     // Add proper exposure logging hook (creates batch internally)

--- a/packages/browser/src/openfeature/provider.ts
+++ b/packages/browser/src/openfeature/provider.ts
@@ -25,7 +25,7 @@ import {
 } from '../domain/configuration'
 import { evaluate } from '../evaluation'
 import { createExposureLoggingHook } from './exposures'
-import { createFlagEvalLoggingHook } from './flagEvaluations'
+import { createFlagEvalEVPHook } from './flagEvaluations'
 import { createRumTrackingHook } from './rumIntegration'
 
 /**
@@ -103,10 +103,10 @@ export class DatadogProvider implements Provider {
       this.hooks.push(createRumTrackingHook())
     }
 
-    // Add flag evaluation logging hook.
+    // Add EVP flag evaluation hook.
     const isEvaluationTrackingEnabled = options.enableFlagEvaluationTracking ?? true
     if (isEvaluationTrackingEnabled && this.configuration) {
-      this.hooks.push(createFlagEvalLoggingHook(this.configuration))
+      this.hooks.push(createFlagEvalEVPHook(this.configuration))
     }
 
     // Add proper exposure logging hook (creates batch internally)

--- a/packages/browser/src/openfeature/provider.ts
+++ b/packages/browser/src/openfeature/provider.ts
@@ -25,7 +25,7 @@ import {
 } from '../domain/configuration'
 import { evaluate } from '../evaluation'
 import { createExposureLoggingHook } from './exposures'
-import { createFlagEvalEVPHook } from './flagEvaluations'
+import { createFlagEvalLoggingHook } from './flagEvaluations'
 import { createRumTrackingHook } from './rumIntegration'
 
 /**
@@ -106,7 +106,7 @@ export class DatadogProvider implements Provider {
     // Add EVP flag evaluation hook.
     const isEvaluationTrackingEnabled = options.enableFlagEvaluationTracking ?? true
     if (isEvaluationTrackingEnabled && this.configuration) {
-      this.hooks.push(createFlagEvalEVPHook(this.configuration))
+      this.hooks.push(createFlagEvalLoggingHook(this.configuration))
     }
 
     // Add proper exposure logging hook (creates batch internally)

--- a/packages/browser/test/evaluation.spec.ts
+++ b/packages/browser/test/evaluation.spec.ts
@@ -26,6 +26,17 @@ describe('evaluate', () => {
     })
   })
 
+  it('returns default without variant metadata for type mismatch', () => {
+    const result = evaluate(configuration, 'string', 'boolean-flag', 'default', {})
+    expect(result).toEqual({
+      value: 'default',
+      reason: 'ERROR',
+      errorCode: 'TYPE_MISMATCH' as ErrorCode,
+    })
+    expect(result).not.toHaveProperty('variant')
+    expect(result).not.toHaveProperty('flagMetadata')
+  })
+
   it('resolves boolean flag', () => {
     const result = evaluate(configuration, 'boolean', 'boolean-flag', true, {})
     expect(result).toEqual({

--- a/packages/browser/test/openfeature/flagEvaluations.spec.ts
+++ b/packages/browser/test/openfeature/flagEvaluations.spec.ts
@@ -1,6 +1,6 @@
 import type { EvaluationDetails, HookContext } from '@openfeature/web-sdk'
 import type { FlaggingConfiguration } from '../../src/domain/configuration'
-import { createFlagEvaluationTrackingHook } from '../../src/openfeature/flagEvaluations'
+import { createFlagEvalEVPHook } from '../../src/openfeature/flagEvaluations'
 
 const mockConfiguration: FlaggingConfiguration = {
   flagEvaluationTrackingInterval: 1000,
@@ -16,8 +16,8 @@ const mockConfiguration: FlaggingConfiguration = {
   telemetrySampleRate: 20,
   // `as unknown as FlaggingConfiguration` is intentional: FlaggingConfiguration inherits many required
   // fields from Configuration/TransportConfiguration (beforeSend, logsEndpointBuilder, sdkVersion, etc.)
-  // that createFlagEvaluationTrackingHook never reads. All @datadog/browser-core imports used by
-  // createFlagEvaluationTrackingHook are mocked at the module level below, so missing fields don't
+  // that createFlagEvalEVPHook never reads. All @datadog/browser-core imports used by
+  // createFlagEvalEVPHook are mocked at the module level below, so missing fields don't
   // cause runtime failures.
 } as unknown as FlaggingConfiguration
 
@@ -36,16 +36,16 @@ jest.mock('@datadog/browser-core', () => ({
   dateNow: jest.fn(() => 1234567890),
 }))
 
-describe('createFlagEvaluationTrackingHook', () => {
+describe('createFlagEvalEVPHook', () => {
   it('should create a hook that tracks flag evaluations', () => {
-    const hook = createFlagEvaluationTrackingHook(mockConfiguration)
+    const hook = createFlagEvalEVPHook(mockConfiguration)
 
     expect(hook).toBeDefined()
     expect(hook.after).toBeDefined()
   })
 
   it('should handle evaluation tracking in after hook', () => {
-    const hook = createFlagEvaluationTrackingHook(mockConfiguration)
+    const hook = createFlagEvalEVPHook(mockConfiguration)
 
     const mockContext: HookContext = {
       flagKey: 'test-flag',

--- a/packages/browser/test/openfeature/flagEvaluations.spec.ts
+++ b/packages/browser/test/openfeature/flagEvaluations.spec.ts
@@ -1,6 +1,6 @@
 import type { EvaluationDetails, HookContext } from '@openfeature/web-sdk'
 import type { FlaggingConfiguration } from '../../src/domain/configuration'
-import { createFlagEvalLoggingHook } from '../../src/openfeature/flagEvaluations'
+import { createFlagEvalEVPHook } from '../../src/openfeature/flagEvaluations'
 
 const mockConfiguration: FlaggingConfiguration = {
   flagEvaluationTrackingInterval: 1000,
@@ -16,8 +16,8 @@ const mockConfiguration: FlaggingConfiguration = {
   telemetrySampleRate: 20,
   // `as unknown as FlaggingConfiguration` is intentional: FlaggingConfiguration inherits many required
   // fields from Configuration/TransportConfiguration (beforeSend, logsEndpointBuilder, sdkVersion, etc.)
-  // that createFlagEvalLoggingHook never reads. All @datadog/browser-core imports used by
-  // createFlagEvalLoggingHook are mocked at the module level below, so missing fields don't
+  // that createFlagEvalEVPHook never reads. All @datadog/browser-core imports used by
+  // createFlagEvalEVPHook are mocked at the module level below, so missing fields don't
   // cause runtime failures.
 } as unknown as FlaggingConfiguration
 
@@ -36,16 +36,16 @@ jest.mock('@datadog/browser-core', () => ({
   dateNow: jest.fn(() => 1234567890),
 }))
 
-describe('createFlagEvalLoggingHook', () => {
+describe('createFlagEvalEVPHook', () => {
   it('should create a hook that tracks flag evaluations', () => {
-    const hook = createFlagEvalLoggingHook(mockConfiguration)
+    const hook = createFlagEvalEVPHook(mockConfiguration)
 
     expect(hook).toBeDefined()
     expect(hook.after).toBeDefined()
   })
 
   it('should handle evaluation tracking in after hook', () => {
-    const hook = createFlagEvalLoggingHook(mockConfiguration)
+    const hook = createFlagEvalEVPHook(mockConfiguration)
 
     const mockContext: HookContext = {
       flagKey: 'test-flag',

--- a/packages/browser/test/openfeature/flagEvaluations.spec.ts
+++ b/packages/browser/test/openfeature/flagEvaluations.spec.ts
@@ -1,6 +1,6 @@
 import type { EvaluationDetails, HookContext } from '@openfeature/web-sdk'
 import type { FlaggingConfiguration } from '../../src/domain/configuration'
-import { createFlagEvalEVPHook } from '../../src/openfeature/flagEvaluations'
+import { createFlagEvalLoggingHook } from '../../src/openfeature/flagEvaluations'
 
 const mockConfiguration: FlaggingConfiguration = {
   flagEvaluationTrackingInterval: 1000,
@@ -16,8 +16,8 @@ const mockConfiguration: FlaggingConfiguration = {
   telemetrySampleRate: 20,
   // `as unknown as FlaggingConfiguration` is intentional: FlaggingConfiguration inherits many required
   // fields from Configuration/TransportConfiguration (beforeSend, logsEndpointBuilder, sdkVersion, etc.)
-  // that createFlagEvalEVPHook never reads. All @datadog/browser-core imports used by
-  // createFlagEvalEVPHook are mocked at the module level below, so missing fields don't
+  // that createFlagEvalLoggingHook never reads. All @datadog/browser-core imports used by
+  // createFlagEvalLoggingHook are mocked at the module level below, so missing fields don't
   // cause runtime failures.
 } as unknown as FlaggingConfiguration
 
@@ -36,16 +36,16 @@ jest.mock('@datadog/browser-core', () => ({
   dateNow: jest.fn(() => 1234567890),
 }))
 
-describe('createFlagEvalEVPHook', () => {
+describe('createFlagEvalLoggingHook', () => {
   it('should create a hook that tracks flag evaluations', () => {
-    const hook = createFlagEvalEVPHook(mockConfiguration)
+    const hook = createFlagEvalLoggingHook(mockConfiguration)
 
     expect(hook).toBeDefined()
     expect(hook.after).toBeDefined()
   })
 
   it('should handle evaluation tracking in after hook', () => {
-    const hook = createFlagEvalEVPHook(mockConfiguration)
+    const hook = createFlagEvalLoggingHook(mockConfiguration)
 
     const mockContext: HookContext = {
       flagKey: 'test-flag',

--- a/packages/browser/test/openfeature/provider.spec.ts
+++ b/packages/browser/test/openfeature/provider.spec.ts
@@ -72,7 +72,7 @@ describe('DatadogProvider', () => {
       expect(providerWithoutExposures.hooks).toHaveLength(2)
     })
 
-    it('should add EVP flag evaluation hook by default when enableFlagEvaluationTracking is not specified', () => {
+    it('should add flag evaluation logging hook by default when enableFlagEvaluationTracking is not specified', () => {
       const providerWithDefaults = new DatadogProvider({
         clientToken: 'xxx',
         applicationId: 'xxx',
@@ -84,7 +84,7 @@ describe('DatadogProvider', () => {
       expect(providerWithDefaults.hooks).toHaveLength(3)
     })
 
-    it('should not add EVP flag evaluation hook when enableFlagEvaluationTracking is false', () => {
+    it('should not add flag evaluation logging hook when enableFlagEvaluationTracking is false', () => {
       const providerWithoutEvalTracking = new DatadogProvider({
         clientToken: 'xxx',
         applicationId: 'xxx',

--- a/packages/browser/test/openfeature/provider.spec.ts
+++ b/packages/browser/test/openfeature/provider.spec.ts
@@ -72,7 +72,7 @@ describe('DatadogProvider', () => {
       expect(providerWithoutExposures.hooks).toHaveLength(2)
     })
 
-    it('should add flag evaluation logging hook by default when enableFlagEvaluationTracking is not specified', () => {
+    it('should add EVP flag evaluation hook by default when enableFlagEvaluationTracking is not specified', () => {
       const providerWithDefaults = new DatadogProvider({
         clientToken: 'xxx',
         applicationId: 'xxx',
@@ -84,7 +84,7 @@ describe('DatadogProvider', () => {
       expect(providerWithDefaults.hooks).toHaveLength(3)
     })
 
-    it('should not add flag evaluation logging hook when enableFlagEvaluationTracking is false', () => {
+    it('should not add EVP flag evaluation hook when enableFlagEvaluationTracking is false', () => {
       const providerWithoutEvalTracking = new DatadogProvider({
         clientToken: 'xxx',
         applicationId: 'xxx',

--- a/packages/browser/test/openfeature/provider.spec.ts
+++ b/packages/browser/test/openfeature/provider.spec.ts
@@ -56,7 +56,7 @@ describe('DatadogProvider', () => {
         site: INTAKE_SITE_STAGING,
         // enableExposureLogging not specified - should default to true
       })
-      // Should have 3 hooks: flag evaluation tracking (default true) + exposure logging (default true) + auto RUM tracking
+      // Should have 3 hooks: EVP flag evaluation (default true) + exposure logging (default true) + auto RUM tracking
       expect(providerWithDefaults.hooks).toHaveLength(3)
     })
 
@@ -68,11 +68,11 @@ describe('DatadogProvider', () => {
         site: INTAKE_SITE_STAGING,
         enableExposureLogging: false,
       })
-      // Should have 2 hooks: flag evaluation tracking + auto RUM tracking
+      // Should have 2 hooks: EVP flag evaluation + auto RUM tracking
       expect(providerWithoutExposures.hooks).toHaveLength(2)
     })
 
-    it('should add flag evaluation tracking hook by default when enableFlagEvaluationTracking is not specified', () => {
+    it('should add EVP flag evaluation hook by default when enableFlagEvaluationTracking is not specified', () => {
       const providerWithDefaults = new DatadogProvider({
         clientToken: 'xxx',
         applicationId: 'xxx',
@@ -80,11 +80,11 @@ describe('DatadogProvider', () => {
         site: INTAKE_SITE_STAGING,
         // enableFlagEvaluationTracking not specified - should default to true
       })
-      // Should have 3 hooks: flag evaluation tracking (default true) + exposure logging (default true) + auto RUM tracking
+      // Should have 3 hooks: EVP flag evaluation (default true) + exposure logging (default true) + auto RUM tracking
       expect(providerWithDefaults.hooks).toHaveLength(3)
     })
 
-    it('should not add flag evaluation tracking hook when enableFlagEvaluationTracking is false', () => {
+    it('should not add EVP flag evaluation hook when enableFlagEvaluationTracking is false', () => {
       const providerWithoutEvalTracking = new DatadogProvider({
         clientToken: 'xxx',
         applicationId: 'xxx',
@@ -117,7 +117,7 @@ describe('DatadogProvider', () => {
         site: INTAKE_SITE_STAGING,
         enableRumFeatureFlagTracking: false,
       })
-      // Should have 2 hooks: flag evaluation tracking + exposure logging
+      // Should have 2 hooks: EVP flag evaluation + exposure logging
       expect(providerWithoutRum.hooks).toHaveLength(2)
     })
 

--- a/packages/core/src/configuration/configuration.ts
+++ b/packages/core/src/configuration/configuration.ts
@@ -49,6 +49,8 @@ export type PrecomputedFlag<T extends FlagValueType = FlagValueType> = {
 
 /** @internal */
 export type PrecomputedFlagMetadata = {
+  // Metadata carried on OpenFeature evaluation details. The type name is kept
+  // for package API compatibility; server fallback/error results also use it.
   // Primary keys (used by browser and core readers)
   allocationKey?: string
   variationType?: FlagValueType

--- a/packages/core/src/configuration/configuration.ts
+++ b/packages/core/src/configuration/configuration.ts
@@ -62,6 +62,7 @@ export type PrecomputedFlagMetadata = {
   __dd_allocation_key?: string
   __dd_do_log?: boolean
   __dd_split_serial_id?: number
+  'dd.eval.timestamp_ms'?: UnixTimestamp
 }
 
 /**

--- a/packages/core/src/configuration/flagEvaluationAggregator.ts
+++ b/packages/core/src/configuration/flagEvaluationAggregator.ts
@@ -118,7 +118,7 @@ export class FlagEvaluationAggregator {
 
 function getEvaluationTimestamp<T extends FlagValue>(details: EvaluationDetails<T>): TimeStamp {
   const metadataTimestamp = details.flagMetadata?.[EVALUATION_TIMESTAMP_METADATA_KEY]
-  return typeof metadataTimestamp === 'number' ? (metadataTimestamp as TimeStamp) : timeStampNow()
+  return Number.isFinite(metadataTimestamp) ? (metadataTimestamp as TimeStamp) : timeStampNow()
 }
 
 function isRuntimeDefaultUsed<T extends FlagValue>(details: EvaluationDetails<T>): boolean {

--- a/packages/core/src/configuration/flagEvaluationAggregator.ts
+++ b/packages/core/src/configuration/flagEvaluationAggregator.ts
@@ -3,6 +3,8 @@ import { getMD5Hash } from '../obfuscation'
 import { createFlagEvaluationEvent } from './flagEvaluationEvent'
 import type { FlagEvaluationEvent } from './flagEvaluationEvent.types'
 
+const EVALUATION_TIMESTAMP_METADATA_KEY = 'dd.eval.timestamp_ms'
+
 interface FlagEvaluationAggregationData {
   flagKey: string
   variantKey?: string
@@ -44,7 +46,7 @@ export class FlagEvaluationAggregator {
 
   addEvaluation<T extends FlagValue>(context: EvaluationContext, details: EvaluationDetails<T>, error?: string): void {
     const keyString = this.createAggregationKeyString(context, details, error)
-    const timestamp = Date.now()
+    const timestamp = getEvaluationTimestamp(details)
 
     const existingData = this.aggregatedData.get(keyString)
     if (existingData) {
@@ -54,7 +56,7 @@ export class FlagEvaluationAggregator {
         existingData.error = error
       }
     } else {
-      const runtimeDefaultUsed = details.reason === 'DEFAULT' || details.reason === 'ERROR'
+      const runtimeDefaultUsed = details.variant == null || details.errorCode === 'TYPE_MISMATCH'
       const allocationKey = details.flagMetadata?.allocationKey as string
       const targetingRuleKey = details.flagMetadata?.targetingRuleKey as string
       const { targetingKey, ...targetingContext } = context
@@ -80,8 +82,9 @@ export class FlagEvaluationAggregator {
       return
     }
 
+    const flushTimestamp = Date.now()
     const events = Array.from(this.aggregatedData.values()).map((data) =>
-      createFlagEvaluationEvent(data, data.firstEvaluation)
+      createFlagEvaluationEvent(data, flushTimestamp)
     )
     this.aggregatedData.clear()
     this.onFlush(events)
@@ -109,4 +112,9 @@ export class FlagEvaluationAggregator {
       })
     )
   }
+}
+
+function getEvaluationTimestamp<T extends FlagValue>(details: EvaluationDetails<T>): number {
+  const metadataTimestamp = details.flagMetadata?.[EVALUATION_TIMESTAMP_METADATA_KEY]
+  return typeof metadataTimestamp === 'number' ? metadataTimestamp : Date.now()
 }

--- a/packages/core/src/configuration/flagEvaluationAggregator.ts
+++ b/packages/core/src/configuration/flagEvaluationAggregator.ts
@@ -122,5 +122,10 @@ function getEvaluationTimestamp<T extends FlagValue>(details: EvaluationDetails<
 }
 
 function isRuntimeDefaultUsed<T extends FlagValue>(details: EvaluationDetails<T>): boolean {
+  // Datadog-assigned evaluations attach a platform variation key to OpenFeature
+  // details.variant. Browser precomputed flags model variationKey as a string, and
+  // server UFC variants are keyed by string. Default/error fallback paths omit the
+  // variant, so nullish variant is the SDK-visible signal that the caller's default
+  // value was returned.
   return details.variant == null
 }

--- a/packages/core/src/configuration/flagEvaluationAggregator.ts
+++ b/packages/core/src/configuration/flagEvaluationAggregator.ts
@@ -122,5 +122,5 @@ function getEvaluationTimestamp<T extends FlagValue>(details: EvaluationDetails<
 }
 
 function isRuntimeDefaultUsed<T extends FlagValue>(details: EvaluationDetails<T>): boolean {
-  return details.variant == null || details.errorCode === 'TYPE_MISMATCH'
+  return details.variant == null
 }

--- a/packages/core/test/configuration/flagEvaluationAggregator.spec.ts
+++ b/packages/core/test/configuration/flagEvaluationAggregator.spec.ts
@@ -284,6 +284,16 @@ describe('FlagEvaluationAggregator', () => {
     }
     aggregator.addEvaluation(mockContext, typeMismatchWithVariantDetails)
 
+    const generalErrorWithVariantDetails: EvaluationDetails<boolean> = {
+      flagKey: 'general-error-with-variant-flag',
+      value: false,
+      reason: 'ERROR',
+      variant: 'variant-a',
+      errorCode: ErrorCode.GENERAL,
+      flagMetadata: {},
+    }
+    aggregator.addEvaluation(mockContext, generalErrorWithVariantDetails)
+
     aggregator.start()
     jest.advanceTimersByTime(100)
 
@@ -311,6 +321,10 @@ describe('FlagEvaluationAggregator', () => {
         }),
         expect.objectContaining({
           flag: { key: 'type-mismatch-flag' },
+          runtime_default_used: false,
+        }),
+        expect.objectContaining({
+          flag: { key: 'general-error-with-variant-flag' },
           runtime_default_used: false,
         }),
       ])

--- a/packages/core/test/configuration/flagEvaluationAggregator.spec.ts
+++ b/packages/core/test/configuration/flagEvaluationAggregator.spec.ts
@@ -1,4 +1,4 @@
-import type { EvaluationContext, EvaluationDetails } from '@openfeature/core'
+import { ErrorCode, type EvaluationContext, type EvaluationDetails } from '@openfeature/core'
 import { FlagEvaluationAggregator } from '../../src/configuration/flagEvaluationAggregator'
 
 describe('FlagEvaluationAggregator', () => {
@@ -13,6 +13,7 @@ describe('FlagEvaluationAggregator', () => {
 
   afterEach(() => {
     aggregator.stop()
+    jest.restoreAllMocks()
     jest.useRealTimers()
   })
 
@@ -137,7 +138,7 @@ describe('FlagEvaluationAggregator', () => {
         targeting_key: 'user123',
         first_evaluation: firstEvalTime,
         last_evaluation: secondEvalTime,
-        timestamp: firstEvalTime,
+        timestamp: flushTime,
       }),
     ])
 
@@ -145,7 +146,44 @@ describe('FlagEvaluationAggregator', () => {
     const flushedEvent = onFlushSpy.mock.calls[0][0][0]
     expect(flushedEvent.first_evaluation).not.toEqual(flushedEvent.last_evaluation)
     expect(flushedEvent.last_evaluation).toBeGreaterThan(flushedEvent.first_evaluation)
-    expect(flushedEvent.timestamp).toEqual(flushedEvent.first_evaluation)
+    expect(flushedEvent.timestamp).toEqual(flushTime)
+  })
+
+  it('should use evaluation metadata for first and last evaluation timestamps', () => {
+    const mockContext: EvaluationContext = { targetingKey: 'user123' }
+    const mockDetails: EvaluationDetails<boolean> = {
+      flagKey: 'test-flag',
+      value: true,
+      variant: 'variant-a',
+      reason: 'TARGETING_MATCH',
+      flagMetadata: {
+        allocationKey: 'allocation-123',
+        'dd.eval.timestamp_ms': 1771771771000,
+      },
+    }
+
+    aggregator.addEvaluation(mockContext, mockDetails)
+    aggregator.addEvaluation(mockContext, {
+      ...mockDetails,
+      flagMetadata: {
+        allocationKey: 'allocation-123',
+        'dd.eval.timestamp_ms': 1771771775000,
+      },
+    })
+
+    jest.spyOn(Date, 'now').mockReturnValue(1771771779000)
+
+    aggregator.start()
+    jest.advanceTimersByTime(100)
+
+    expect(onFlushSpy).toHaveBeenCalledWith([
+      expect.objectContaining({
+        flag: { key: 'test-flag' },
+        first_evaluation: 1771771771000,
+        last_evaluation: 1771771775000,
+        timestamp: 1771771779000,
+      }),
+    ])
   })
 
   it('should fire multiple events when targeting context changes but flag variant stays same', () => {
@@ -192,10 +230,9 @@ describe('FlagEvaluationAggregator', () => {
     expect(onFlushSpy.mock.calls[0][0]).toHaveLength(2)
   })
 
-  it('should populate runtime_default_used correctly for DEFAULT and ERROR reasons', () => {
+  it('should populate runtime_default_used from variant absence and type mismatch', () => {
     const mockContext: EvaluationContext = { targetingKey: 'user123' }
 
-    // Test DEFAULT reason
     const defaultDetails: EvaluationDetails<boolean> = {
       flagKey: 'default-flag',
       value: false,
@@ -213,7 +250,6 @@ describe('FlagEvaluationAggregator', () => {
     }
     aggregator.addEvaluation(mockContext, errorDetails, 'Some error')
 
-    // Test non-default reason
     const targetingDetails: EvaluationDetails<boolean> = {
       flagKey: 'targeting-flag',
       value: true,
@@ -222,6 +258,25 @@ describe('FlagEvaluationAggregator', () => {
       flagMetadata: {},
     }
     aggregator.addEvaluation(mockContext, targetingDetails)
+
+    const reasonOnlyDefaultDetails: EvaluationDetails<boolean> = {
+      flagKey: 'reason-only-default-flag',
+      value: true,
+      reason: 'DEFAULT',
+      variant: 'variant-a',
+      flagMetadata: {},
+    }
+    aggregator.addEvaluation(mockContext, reasonOnlyDefaultDetails)
+
+    const typeMismatchDetails: EvaluationDetails<boolean> = {
+      flagKey: 'type-mismatch-flag',
+      value: false,
+      reason: 'ERROR',
+      variant: 'variant-a',
+      errorCode: ErrorCode.TYPE_MISMATCH,
+      flagMetadata: {},
+    }
+    aggregator.addEvaluation(mockContext, typeMismatchDetails)
 
     aggregator.start()
     jest.advanceTimersByTime(100)
@@ -239,6 +294,14 @@ describe('FlagEvaluationAggregator', () => {
         expect.objectContaining({
           flag: { key: 'targeting-flag' },
           runtime_default_used: false,
+        }),
+        expect.objectContaining({
+          flag: { key: 'reason-only-default-flag' },
+          runtime_default_used: false,
+        }),
+        expect.objectContaining({
+          flag: { key: 'type-mismatch-flag' },
+          runtime_default_used: true,
         }),
       ])
     )

--- a/packages/core/test/configuration/flagEvaluationAggregator.spec.ts
+++ b/packages/core/test/configuration/flagEvaluationAggregator.spec.ts
@@ -274,16 +274,6 @@ describe('FlagEvaluationAggregator', () => {
     }
     aggregator.addEvaluation(mockContext, reasonOnlyErrorDetails)
 
-    const typeMismatchWithVariantDetails: EvaluationDetails<boolean> = {
-      flagKey: 'type-mismatch-flag',
-      value: false,
-      reason: 'ERROR',
-      variant: 'variant-a',
-      errorCode: ErrorCode.TYPE_MISMATCH,
-      flagMetadata: {},
-    }
-    aggregator.addEvaluation(mockContext, typeMismatchWithVariantDetails)
-
     const generalErrorWithVariantDetails: EvaluationDetails<boolean> = {
       flagKey: 'general-error-with-variant-flag',
       value: false,
@@ -317,10 +307,6 @@ describe('FlagEvaluationAggregator', () => {
         }),
         expect.objectContaining({
           flag: { key: 'reason-only-error-flag' },
-          runtime_default_used: false,
-        }),
-        expect.objectContaining({
-          flag: { key: 'type-mismatch-flag' },
           runtime_default_used: false,
         }),
         expect.objectContaining({

--- a/packages/core/test/configuration/flagEvaluationAggregator.spec.ts
+++ b/packages/core/test/configuration/flagEvaluationAggregator.spec.ts
@@ -184,6 +184,37 @@ describe('FlagEvaluationAggregator', () => {
     ])
   })
 
+  it('should fall back to current time when evaluation metadata timestamp is NaN', () => {
+    const mockContext: EvaluationContext = { targetingKey: 'user123' }
+    const mockDetails: EvaluationDetails<boolean> = {
+      flagKey: 'test-flag',
+      value: true,
+      variant: 'variant-a',
+      reason: 'TARGETING_MATCH',
+      flagMetadata: {
+        allocationKey: 'allocation-123',
+        __dd_eval_timestamp_ms: Number.NaN,
+      },
+    }
+
+    const evalTime = 1771771779000
+    jest.setSystemTime(evalTime)
+    aggregator.addEvaluation(mockContext, mockDetails)
+
+    const flushTime = evalTime + 100
+    aggregator.start()
+    jest.advanceTimersByTime(100)
+
+    expect(onFlushSpy).toHaveBeenCalledWith([
+      expect.objectContaining({
+        flag: { key: 'test-flag' },
+        first_evaluation: evalTime,
+        last_evaluation: evalTime,
+        timestamp: flushTime,
+      }),
+    ])
+  })
+
   it('should fire multiple events when targeting context changes but flag variant stays same', () => {
     const baseDetails: EvaluationDetails<boolean> = {
       flagKey: 'test-flag',

--- a/packages/core/test/configuration/flagEvaluationAggregator.spec.ts
+++ b/packages/core/test/configuration/flagEvaluationAggregator.spec.ts
@@ -228,7 +228,7 @@ describe('FlagEvaluationAggregator', () => {
     expect(onFlushSpy.mock.calls[0][0]).toHaveLength(2)
   })
 
-  it('should populate runtime_default_used from missing variant and type mismatch, not reason alone', () => {
+  it('should populate runtime_default_used from missing variant, not reason or error code alone', () => {
     const mockContext: EvaluationContext = { targetingKey: 'user123' }
 
     const defaultDetails: EvaluationDetails<boolean> = {
@@ -274,7 +274,7 @@ describe('FlagEvaluationAggregator', () => {
     }
     aggregator.addEvaluation(mockContext, reasonOnlyErrorDetails)
 
-    const typeMismatchDetails: EvaluationDetails<boolean> = {
+    const typeMismatchWithVariantDetails: EvaluationDetails<boolean> = {
       flagKey: 'type-mismatch-flag',
       value: false,
       reason: 'ERROR',
@@ -282,7 +282,7 @@ describe('FlagEvaluationAggregator', () => {
       errorCode: ErrorCode.TYPE_MISMATCH,
       flagMetadata: {},
     }
-    aggregator.addEvaluation(mockContext, typeMismatchDetails)
+    aggregator.addEvaluation(mockContext, typeMismatchWithVariantDetails)
 
     aggregator.start()
     jest.advanceTimersByTime(100)
@@ -311,7 +311,7 @@ describe('FlagEvaluationAggregator', () => {
         }),
         expect.objectContaining({
           flag: { key: 'type-mismatch-flag' },
-          runtime_default_used: true,
+          runtime_default_used: false,
         }),
       ])
     )

--- a/packages/node-server/src/configuration/evaluateForSubject.ts
+++ b/packages/node-server/src/configuration/evaluateForSubject.ts
@@ -12,6 +12,7 @@ import {
 } from '@openfeature/server-sdk'
 import { matchesRule, type Rule } from '../rules/rules'
 import { matchesShard } from '../shards/matchesShard'
+import { createEvaluationTimestampMetadata } from './evaluationMetadata'
 import { type Flag, type Split, type VariantType, variantTypeToFlagValueType } from './ufc-v1'
 
 export function evaluateForSubject<T extends FlagValueType>(
@@ -125,10 +126,6 @@ export function evaluateForSubject<T extends FlagValueType>(
     reason: StandardResolutionReasons.DEFAULT,
     flagMetadata: createEvaluationTimestampMetadata(evaluationTimestampMs),
   }
-}
-
-function createEvaluationTimestampMetadata(evaluationTimestampMs: TimeStamp): PrecomputedFlagMetadata {
-  return { __dd_eval_timestamp_ms: evaluationTimestampMs } as PrecomputedFlagMetadata
 }
 
 function validateTypeMatch(expectedType: FlagValueType, variantType: VariantType): boolean {

--- a/packages/node-server/src/configuration/evaluateForSubject.ts
+++ b/packages/node-server/src/configuration/evaluateForSubject.ts
@@ -1,4 +1,4 @@
-import type { FlagTypeToValue, PrecomputedFlagMetadata } from '@datadog/flagging-core'
+import type { FlagTypeToValue, PrecomputedFlagMetadata, UnixTimestamp } from '@datadog/flagging-core'
 import {
   ErrorCode,
   type EvaluationContext,
@@ -18,7 +18,8 @@ export function evaluateForSubject<T extends FlagValueType>(
   subjectKey: string | null | undefined,
   subjectAttributes: EvaluationContext,
   defaultValue: FlagTypeToValue<T>,
-  logger: Logger
+  logger: Logger,
+  evaluationTimestampMs: UnixTimestamp = Date.now()
 ): ResolutionDetails<FlagTypeToValue<T>> {
   if (!flag.enabled) {
     logger.debug(`returning default assignment because flag is disabled`, {
@@ -28,6 +29,7 @@ export function evaluateForSubject<T extends FlagValueType>(
     return {
       value: defaultValue,
       reason: StandardResolutionReasons.DISABLED,
+      flagMetadata: createEvaluationTimestampMetadata(evaluationTimestampMs),
     }
   }
 
@@ -43,10 +45,11 @@ export function evaluateForSubject<T extends FlagValueType>(
       value: defaultValue,
       reason: StandardResolutionReasons.ERROR,
       errorCode: ErrorCode.TYPE_MISMATCH,
+      flagMetadata: createEvaluationTimestampMetadata(evaluationTimestampMs),
     }
   }
 
-  const now = new Date()
+  const now = new Date(evaluationTimestampMs)
   for (const allocation of flag.allocations) {
     if (allocation.startAt && now < new Date(allocation.startAt)) {
       logger.debug(`allocation before start date`, {
@@ -88,6 +91,7 @@ export function evaluateForSubject<T extends FlagValueType>(
           reason: StandardResolutionReasons.TARGETING_MATCH,
           variant: variant.key,
           flagMetadata: {
+            ...createEvaluationTimestampMetadata(evaluationTimestampMs),
             // Keys for dd-trace-js
             __dd_allocation_key: allocation.key,
             __dd_do_log: !!allocation.doLog,
@@ -117,7 +121,12 @@ export function evaluateForSubject<T extends FlagValueType>(
   return {
     value: defaultValue,
     reason: StandardResolutionReasons.DEFAULT,
+    flagMetadata: createEvaluationTimestampMetadata(evaluationTimestampMs),
   }
+}
+
+function createEvaluationTimestampMetadata(evaluationTimestampMs: UnixTimestamp): PrecomputedFlagMetadata {
+  return { 'dd.eval.timestamp_ms': evaluationTimestampMs } as PrecomputedFlagMetadata
 }
 
 function validateTypeMatch(expectedType: FlagValueType, variantType: VariantType): boolean {

--- a/packages/node-server/src/configuration/evaluation.ts
+++ b/packages/node-server/src/configuration/evaluation.ts
@@ -1,5 +1,4 @@
-import type { FlagTypeToValue, PrecomputedFlagMetadata } from '@datadog/flagging-core'
-import type { TimeStamp } from '@datadog/js-core/time'
+import type { FlagTypeToValue } from '@datadog/flagging-core'
 import { timeStampNow } from '@datadog/js-core/time'
 import {
   ErrorCode,
@@ -11,6 +10,7 @@ import {
   TargetingKeyMissingError,
 } from '@openfeature/server-sdk'
 import { evaluateForSubject } from './evaluateForSubject'
+import { createEvaluationTimestampMetadata } from './evaluationMetadata'
 import type { UniversalFlagConfigurationV1 } from './ufc-v1'
 
 export function evaluate<T extends FlagValueType>(
@@ -78,8 +78,4 @@ export function evaluate<T extends FlagValueType>(
       flagMetadata: createEvaluationTimestampMetadata(evaluationTimestampMs),
     }
   }
-}
-
-function createEvaluationTimestampMetadata(evaluationTimestampMs: TimeStamp): PrecomputedFlagMetadata {
-  return { __dd_eval_timestamp_ms: evaluationTimestampMs } as PrecomputedFlagMetadata
 }

--- a/packages/node-server/src/configuration/evaluation.ts
+++ b/packages/node-server/src/configuration/evaluation.ts
@@ -1,4 +1,4 @@
-import type { FlagTypeToValue } from '@datadog/flagging-core'
+import type { FlagTypeToValue, PrecomputedFlagMetadata, UnixTimestamp } from '@datadog/flagging-core'
 import {
   ErrorCode,
   type EvaluationContext,
@@ -19,11 +19,14 @@ export function evaluate<T extends FlagValueType>(
   context: EvaluationContext,
   logger: Logger
 ): ResolutionDetails<FlagTypeToValue<T>> {
+  const evaluationTimestampMs = Date.now()
+
   if (!config) {
     return {
       value: defaultValue,
       reason: 'ERROR',
       errorCode: ErrorCode.PROVIDER_NOT_READY,
+      flagMetadata: createEvaluationTimestampMetadata(evaluationTimestampMs),
     }
   }
 
@@ -41,11 +44,20 @@ export function evaluate<T extends FlagValueType>(
       value: defaultValue,
       reason: StandardResolutionReasons.ERROR,
       errorCode: ErrorCode.FLAG_NOT_FOUND,
+      flagMetadata: createEvaluationTimestampMetadata(evaluationTimestampMs),
     }
   }
 
   try {
-    const resultWithDetails = evaluateForSubject(flag, type, subjectKey, subjectAttributes, defaultValue, logger)
+    const resultWithDetails = evaluateForSubject(
+      flag,
+      type,
+      subjectKey,
+      subjectAttributes,
+      defaultValue,
+      logger,
+      evaluationTimestampMs
+    )
     return resultWithDetails
   } catch (error) {
     if (error instanceof TargetingKeyMissingError) {
@@ -53,6 +65,7 @@ export function evaluate<T extends FlagValueType>(
         value: defaultValue,
         reason: StandardResolutionReasons.ERROR,
         errorCode: ErrorCode.TARGETING_KEY_MISSING,
+        flagMetadata: createEvaluationTimestampMetadata(evaluationTimestampMs),
       }
     }
     logger.error('Error evaluating flag', { error })
@@ -60,6 +73,11 @@ export function evaluate<T extends FlagValueType>(
       value: defaultValue,
       reason: StandardResolutionReasons.ERROR,
       errorCode: ErrorCode.GENERAL,
+      flagMetadata: createEvaluationTimestampMetadata(evaluationTimestampMs),
     }
   }
+}
+
+function createEvaluationTimestampMetadata(evaluationTimestampMs: UnixTimestamp): PrecomputedFlagMetadata {
+  return { 'dd.eval.timestamp_ms': evaluationTimestampMs } as PrecomputedFlagMetadata
 }

--- a/packages/node-server/src/configuration/evaluationMetadata.ts
+++ b/packages/node-server/src/configuration/evaluationMetadata.ts
@@ -1,0 +1,6 @@
+import type { PrecomputedFlagMetadata } from '@datadog/flagging-core'
+import type { TimeStamp } from '@datadog/js-core/time'
+
+export function createEvaluationTimestampMetadata(evaluationTimestampMs: TimeStamp): PrecomputedFlagMetadata {
+  return { __dd_eval_timestamp_ms: evaluationTimestampMs } as PrecomputedFlagMetadata
+}

--- a/packages/node-server/test/evaluateForSubject.spec.ts
+++ b/packages/node-server/test/evaluateForSubject.spec.ts
@@ -14,6 +14,48 @@ describe('evaluateForSubject', () => {
     }
   })
 
+  it('should include evaluation entry timestamp in flagMetadata', () => {
+    const evaluationTimestampMs = new Date('2026-06-22T12:34:56.789Z').getTime()
+    const dateNow = jest.spyOn(Date, 'now').mockReturnValue(evaluationTimestampMs)
+
+    try {
+      const flag: Flag = {
+        key: 'timestamped-flag',
+        enabled: true,
+        variationType: 'BOOLEAN',
+        variations: {
+          'on-variation': { key: 'on-variation', value: true },
+        },
+        allocations: [
+          {
+            key: 'timestamped-allocation',
+            doLog: true,
+            splits: [
+              {
+                variationKey: 'on-variation',
+                shards: [
+                  {
+                    salt: 'test-salt',
+                    ranges: [{ start: 0, end: 10000 }],
+                    totalShards: 10000,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }
+
+      const context: EvaluationContext = { targetingKey: 'user-123' }
+      const result = evaluateForSubject(flag, 'boolean', 'user-123', context, false, logger)
+
+      expect(result.value).toBe(true)
+      expect(result.flagMetadata?.['dd.eval.timestamp_ms']).toBe(evaluationTimestampMs)
+    } finally {
+      dateNow.mockRestore()
+    }
+  })
+
   describe('__dd_split_serial_id passthrough', () => {
     it('should pass through serialId from split to flagMetadata.__dd_split_serial_id', () => {
       const serialId = 12345
@@ -150,11 +192,14 @@ describe('evaluateForSubject', () => {
       }
 
       const context: EvaluationContext = { targetingKey: 'user-123' }
-      const result = evaluateForSubject(flag, 'boolean', 'user-123', context, false, logger)
+      const evaluationTimestampMs = new Date('2026-06-22T12:34:56.789Z').getTime()
+      const result = evaluateForSubject(flag, 'boolean', 'user-123', context, false, logger, evaluationTimestampMs)
 
       expect(result.value).toBe(false)
       expect(result.reason).toBe('DISABLED')
-      expect(result.flagMetadata).toBeUndefined()
+      expect(result.flagMetadata?.['dd.eval.timestamp_ms']).toBe(evaluationTimestampMs)
+      expect(result.variant).toBeUndefined()
+      expect(result.flagMetadata?.allocationKey).toBeUndefined()
     })
   })
 
@@ -181,11 +226,15 @@ describe('evaluateForSubject', () => {
       }
 
       const context: EvaluationContext = { targetingKey: 'user-123' }
-      const result = evaluateForSubject(flag, 'string', 'user-123', context, 'default', logger)
+      const evaluationTimestampMs = new Date('2026-06-22T12:34:56.789Z').getTime()
+      const result = evaluateForSubject(flag, 'string', 'user-123', context, 'default', logger, evaluationTimestampMs)
 
       expect(result.value).toBe('default')
       expect(result.reason).toBe('ERROR')
       expect(result.errorCode).toBe('TYPE_MISMATCH')
+      expect(result.flagMetadata?.['dd.eval.timestamp_ms']).toBe(evaluationTimestampMs)
+      expect(result.variant).toBeUndefined()
+      expect(result.flagMetadata?.allocationKey).toBeUndefined()
     })
   })
 })

--- a/packages/node-server/test/initialization-controller.spec.ts
+++ b/packages/node-server/test/initialization-controller.spec.ts
@@ -1,12 +1,18 @@
+import { clearTimeout as realClearTimeout, setTimeout as realSetTimeout } from 'node:timers'
 import { InitializationController } from '../src/initialization-controller'
 
 describe('InitializationController', () => {
   beforeEach(() => {
+    jest.useRealTimers()
     jest.clearAllTimers()
+    globalThis.setTimeout = realSetTimeout as typeof globalThis.setTimeout
+    globalThis.clearTimeout = realClearTimeout as typeof globalThis.clearTimeout
   })
 
   afterEach(() => {
     jest.useRealTimers()
+    globalThis.setTimeout = realSetTimeout as typeof globalThis.setTimeout
+    globalThis.clearTimeout = realClearTimeout as typeof globalThis.clearTimeout
   })
 
   it('should complete initialization successfully', async () => {

--- a/packages/node-server/test/provider.spec.ts
+++ b/packages/node-server/test/provider.spec.ts
@@ -1,6 +1,7 @@
 import type { Channel } from 'node:diagnostics_channel'
 import fs from 'node:fs'
 import path from 'node:path'
+import { clearTimeout as realClearTimeout, setTimeout as realSetTimeout } from 'node:timers'
 import type { ExposureEvent } from '@datadog/flagging-core'
 import {
   type BaseHook,
@@ -38,12 +39,21 @@ describe('DatadogNodeServerProvider', () => {
   })()
 
   beforeEach(() => {
+    jest.useRealTimers()
+    globalThis.setTimeout = realSetTimeout as typeof globalThis.setTimeout
+    globalThis.clearTimeout = realClearTimeout as typeof globalThis.clearTimeout
     logger = {
       error: console.error,
       warn: console.warn,
       info: console.info,
       debug: jest.fn(),
     }
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    globalThis.setTimeout = realSetTimeout as typeof globalThis.setTimeout
+    globalThis.clearTimeout = realClearTimeout as typeof globalThis.clearTimeout
   })
 
   function getConfigurationWithDoLogEnabledOrDisabled(
@@ -116,6 +126,40 @@ describe('DatadogNodeServerProvider', () => {
     expect(afterHook).toHaveBeenCalled()
   }, 1000)
 
+  it('should expose evaluation entry timestamp metadata to hooks', async () => {
+    const evaluationTimestampMs = new Date('2026-06-22T12:34:56.789Z').getTime()
+    const dateNow = jest.spyOn(Date, 'now').mockReturnValue(evaluationTimestampMs)
+
+    try {
+      const provider = new DatadogNodeServerProvider({
+        exposureChannel: mockExposureChannel,
+      })
+      provider.setConfiguration(configuration)
+      await OpenFeature.setProviderAndWait(provider)
+      OpenFeature.setLogger(logger)
+      OpenFeature.setContext({ targetingKey: 'test-user-123' })
+      const client = OpenFeature.getClient()
+      const afterHook = jest.fn()
+      const testHook: BaseHook = {
+        after: (
+          _hookContext: HookContext<FlagValue>,
+          evaluationDetails: EvaluationDetails<FlagValue>,
+          _hookHints?: HookHints
+        ) => {
+          afterHook(evaluationDetails.flagMetadata?.['dd.eval.timestamp_ms'])
+        },
+      }
+      client.addHooks(testHook)
+
+      const details = await client.getBooleanDetails('kill-switch', false)
+
+      expect(details.flagMetadata?.['dd.eval.timestamp_ms']).toBe(evaluationTimestampMs)
+      expect(afterHook).toHaveBeenCalledWith(evaluationTimestampMs)
+    } finally {
+      dateNow.mockRestore()
+    }
+  }, 1000)
+
   it('should return FLAG_NOT_FOUND error for non-existent flags', async () => {
     const provider = new DatadogNodeServerProvider({
       exposureChannel: mockExposureChannel,
@@ -125,12 +169,20 @@ describe('DatadogNodeServerProvider', () => {
     OpenFeature.setLogger(logger)
     OpenFeature.setContext({ targetingKey: 'test-user-123' })
     const client = OpenFeature.getClient()
+    const evaluationTimestampMs = new Date('2026-06-22T12:34:56.789Z').getTime()
+    const dateNow = jest.spyOn(Date, 'now').mockReturnValue(evaluationTimestampMs)
 
-    const details = await client.getBooleanDetails('flag-that-does-not-exist', false)
+    try {
+      const details = await client.getBooleanDetails('flag-that-does-not-exist', false)
 
-    expect(details.value).toBe(false)
-    expect(details.reason).toBe(StandardResolutionReasons.ERROR)
-    expect(details.errorCode).toBe(ErrorCode.FLAG_NOT_FOUND)
+      expect(details.value).toBe(false)
+      expect(details.reason).toBe(StandardResolutionReasons.ERROR)
+      expect(details.errorCode).toBe(ErrorCode.FLAG_NOT_FOUND)
+      expect(details.flagMetadata?.['dd.eval.timestamp_ms']).toBe(evaluationTimestampMs)
+      expect(details.variant).toBeUndefined()
+    } finally {
+      dateNow.mockRestore()
+    }
   }, 1000)
 
   it('should return TYPE_MISMATCH error when evaluating wrong type', async () => {
@@ -142,13 +194,21 @@ describe('DatadogNodeServerProvider', () => {
     OpenFeature.setLogger(logger)
     OpenFeature.setContext({ targetingKey: 'test-user-123' })
     const client = OpenFeature.getClient()
+    const evaluationTimestampMs = new Date('2026-06-22T12:34:56.789Z').getTime()
+    const dateNow = jest.spyOn(Date, 'now').mockReturnValue(evaluationTimestampMs)
 
-    // kill-switch is a BOOLEAN flag, evaluate it as STRING
-    const details = await client.getStringDetails('kill-switch', 'default')
+    try {
+      // kill-switch is a BOOLEAN flag, evaluate it as STRING
+      const details = await client.getStringDetails('kill-switch', 'default')
 
-    expect(details.value).toBe('default')
-    expect(details.reason).toBe(StandardResolutionReasons.ERROR)
-    expect(details.errorCode).toBe(ErrorCode.TYPE_MISMATCH)
+      expect(details.value).toBe('default')
+      expect(details.reason).toBe(StandardResolutionReasons.ERROR)
+      expect(details.errorCode).toBe(ErrorCode.TYPE_MISMATCH)
+      expect(details.flagMetadata?.['dd.eval.timestamp_ms']).toBe(evaluationTimestampMs)
+      expect(details.variant).toBeUndefined()
+    } finally {
+      dateNow.mockRestore()
+    }
   }, 1000)
 
   it('should only emit ready event after configuration is set', async () => {


### PR DESCRIPTION
## Motivation

Node.js server-side flag-evaluation EVP delivery depends on the OpenFeature node-server package providing accurate evaluation metadata to `dd-trace-js`. Customers need Node.js evaluations to land in the same backend `flagevaluation` signal as the other SDKs, and APM needs that signal to reflect evaluation time, runtime-default behavior, and bounded context consistently across runtimes.

## Changes

- Adds `__dd_eval_timestamp_ms` evaluation-entry metadata to node-server resolution details so EVP `first_evaluation` and `last_evaluation` come from evaluation time rather than flush time.
- Uses js-core `timeStampNow()` for typed evaluation and outbound EVP envelope timestamps.
- Treats runtime default as absent variant, not OpenFeature `reason` or `errorCode` alone.
- Keeps targeting key as the dedicated EVP field and prevents duplicate `targetingKey`/`targeting_key` entries in `context.evaluation`.
- Allows error/default metadata to carry only internal tracing metadata when no allocation metadata exists.
- Renames the browser flag-evaluation hook implementation from generic tracking language to `createFlagEvalEVPHook`, matching the cross-SDK metrics-vs-EVP split.
- Adds coverage for timestamp metadata, runtime-default semantics, and provider hook visibility.
- Stabilizes affected timer tests around Jest system time.

## Decisions

- `__dd_eval_timestamp_ms` uses the existing `__dd_*` internal metadata namespace for SDK-to-tracer coordination; it is not a public API promise.
- Runtime-default derivation follows the provider result shape: an absent variant means the SDK returned the caller default. OpenFeature `reason` and `errorCode` are not used as independent runtime-default truth because they are not part of the flagevaluation EVP cardinality contract.
- The TypeScript aggregator keeps the runtime-default rule local and schema-oriented. Type mismatch remains an OpenFeature resolution detail, but this provider's type-mismatch path already reaches the aggregator without a variant when it uses the caller default.
- Browser hook implementation names use the same metrics-vs-EVP split as the tracer SDKs; payload, event, and aggregator types keep `FlagEvaluation*` names because those describe the transport contract rather than a hook role.
- Error/default resolution metadata can be partial because those paths need to preserve evaluation timing even when no allocation, variation type, or exposure `doLog` metadata exists.
- This is a companion to the `dd-trace-js` Node.js EVP writer draft; the writer remains in the tracer repo while this package supplies canonical evaluation metadata.

## Validation Evidence

### Dogfooding App

- Companion Node.js tracer draft: https://github.com/DataDog/dd-trace-js/pull/8902
- `ffe-dogfooding` `app-nodejs` was run with local `dd-trace-js`, `@datadog/flagging-core`, and `@datadog/openfeature-node-server` artifacts and reached `PROVIDER_READY`.
- Evaluated `ffe-dogfooding-string-flag` five times for each public-safe targeting key, keeping the evaluation context stable per key so batching/aggregation is observable:
  - `nodejs-batch-evp-agent-20260623T024835Z-alpha`
  - `nodejs-batch-evp-agent-20260623T024835Z-bravo`
  - `nodejs-batch-evp-agent-20260623T024835Z-charlie`
- App-side result: all 15 evaluations returned `variant_2` with `reason=TARGETING_MATCH`.

### System Tests

- Companion draft PR: https://github.com/DataDog/system-tests/pull/7182

### Staging End-To-End

- Dogfooding ran without the local mock-intake EVP tee/proxy, so the Agent sent EVP traffic through the normal backend path.
- Retriever staging query used `eventplatform.system.track(TRACK => 'flagevaluation')` against `us1.staging.dog` for the exact targeting keys above.
- Backend rows observed:
  - `nodejs-batch-evp-agent-20260623T024835Z-alpha`: `evaluation_count=5`, `flag.key=ffe-dogfooding-string-flag`, `variant.key=variant_2`, `allocation.key=allocation-override-392dd7c149f8`
  - `nodejs-batch-evp-agent-20260623T024835Z-bravo`: `evaluation_count=5`, `flag.key=ffe-dogfooding-string-flag`, `variant.key=variant_2`, `allocation.key=allocation-override-392dd7c149f8`
  - `nodejs-batch-evp-agent-20260623T024835Z-charlie`: `evaluation_count=5`, `flag.key=ffe-dogfooding-string-flag`, `variant.key=variant_2`, `allocation.key=allocation-override-392dd7c149f8`

