### PR TITLE
fix(browser): add descriptive reason to aborts from superseded context

### DIFF
--- a/packages/browser/src/openfeature/provider.ts
+++ b/packages/browser/src/openfeature/provider.ts
@@ -145,7 +145,9 @@ export class DatadogProvider implements Provider {
     }
 
     // abort any previous setContext operation
-    this.contextUpdateAbortController.abort()
+    this.contextUpdateAbortController.abort(
+      new DOMException('Flag configuration fetch superseded by a newer context update', 'AbortError')
+    )
     this.contextUpdateAbortController = new AbortController()
 
     const signal = this.contextUpdateAbortController.signal


### PR DESCRIPTION
## Motivation

The provider calls AbortController.abort() with no argument when a newer setContext supersedes an in-flight precompute-assignments fetch. The browser then surfaces the generic "signal is aborted without reason" AbortError, which RUM/error trackers record as noise even though the provider handles the abort cleanly and flag resolution is unaffected.

## Changes

Pass a named AbortError with a descriptive reason so the rejection is self-documenting and consumers can reliably filter intentional supersession aborts without masking genuine fetch failures. The DOMException is still named 'AbortError', so all existing signal.aborted handling is preserved.

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Updated Documentation
- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/openfeature-js-client/blob/main/CONTRIBUTING.md -->
