### PR TITLE
feat(browser): add DatadogDevtools wrapper provider for flag overrides

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -3,6 +3,7 @@ import { DatadogProvider } from './openfeature/provider'
 
 export { configurationFromString, configurationToString } from '@datadog/flagging-core'
 export type { FlaggingInitConfiguration } from './domain/configuration'
+export { DatadogDevtools } from './openfeature/devtools-provider'
 export { DatadogProvider }
 
 // Build environment placeholder for testing

--- a/packages/browser/src/openfeature/devtools-provider.ts
+++ b/packages/browser/src/openfeature/devtools-provider.ts
@@ -113,7 +113,10 @@ export class DatadogDevtools implements Provider {
     context: EvaluationContext,
     logger: Logger
   ): ResolutionDetails<boolean> {
-    return this.resolveOverride<boolean>(flagKey, ['BOOLEAN']) ?? this.inner.resolveBooleanEvaluation(flagKey, defaultValue, context, logger)
+    return (
+      this.resolveOverride<boolean>(flagKey, ['BOOLEAN']) ??
+      this.inner.resolveBooleanEvaluation(flagKey, defaultValue, context, logger)
+    )
   }
 
   resolveStringEvaluation(
@@ -122,7 +125,10 @@ export class DatadogDevtools implements Provider {
     context: EvaluationContext,
     logger: Logger
   ): ResolutionDetails<string> {
-    return this.resolveOverride<string>(flagKey, ['STRING']) ?? this.inner.resolveStringEvaluation(flagKey, defaultValue, context, logger)
+    return (
+      this.resolveOverride<string>(flagKey, ['STRING']) ??
+      this.inner.resolveStringEvaluation(flagKey, defaultValue, context, logger)
+    )
   }
 
   resolveNumberEvaluation(
@@ -143,6 +149,9 @@ export class DatadogDevtools implements Provider {
     context: EvaluationContext,
     logger: Logger
   ): ResolutionDetails<T> {
-    return this.resolveOverride<T>(flagKey, ['JSON']) ?? this.inner.resolveObjectEvaluation(flagKey, defaultValue, context, logger)
+    return (
+      this.resolveOverride<T>(flagKey, ['JSON']) ??
+      this.inner.resolveObjectEvaluation(flagKey, defaultValue, context, logger)
+    )
   }
 }

--- a/packages/browser/src/openfeature/devtools-provider.ts
+++ b/packages/browser/src/openfeature/devtools-provider.ts
@@ -1,0 +1,148 @@
+import type {
+  EvaluationContext,
+  JsonValue,
+  Logger,
+  Paradigm,
+  Provider,
+  ProviderMetadata,
+  ResolutionDetails,
+} from '@openfeature/web-sdk'
+import { TypeMismatchError } from '@openfeature/web-sdk'
+
+const OVERRIDES_KEY = 'dd.dd_flag.overrides'
+const DEVTOOLS_MARKER_KEY = 'dd.dd_flag.devtools'
+
+type DDFlagOverrideType = 'BOOLEAN' | 'STRING' | 'INTEGER' | 'NUMERIC' | 'JSON'
+
+interface DDFlagOverride {
+  type: DDFlagOverrideType
+  value: boolean | string | number | JsonValue
+}
+
+function readOverrides(): Record<string, DDFlagOverride> {
+  try {
+    return JSON.parse(localStorage.getItem(OVERRIDES_KEY) ?? '{}') as Record<string, DDFlagOverride>
+  } catch {
+    return {}
+  }
+}
+
+const EXPECTED_JS_TYPES: Record<DDFlagOverrideType, string> = {
+  BOOLEAN: 'boolean',
+  STRING: 'string',
+  INTEGER: 'number',
+  NUMERIC: 'number',
+  JSON: 'object',
+}
+
+/**
+ * Wraps any OpenFeature Provider to add localStorage-based flag overrides for local development.
+ *
+ * Overrides are loaded once on initialize() from localStorage['dd.dd_flag.overrides'].
+ * On override hit, returns the value with flagMetadata.overridden = true and reason STATIC.
+ * On miss, delegates to the inner provider unchanged.
+ *
+ * Usage:
+ *   OpenFeature.setProvider(new DatadogDevtools(new DatadogProvider(...)))
+ *
+ * Set overrides in localStorage:
+ *   localStorage.setItem('dd.dd_flag.overrides', JSON.stringify({
+ *     'my-flag': { type: 'BOOLEAN', value: true }
+ *   }))
+ */
+export class DatadogDevtools implements Provider {
+  readonly metadata: ProviderMetadata = { name: 'DatadogDevtools' }
+  readonly runsOn: Paradigm = 'client'
+
+  private overrides: Record<string, DDFlagOverride> = {}
+
+  constructor(private readonly inner: Provider) {}
+
+  get hooks() {
+    return this.inner.hooks
+  }
+
+  get events() {
+    return this.inner.events
+  }
+
+  get status() {
+    return this.inner.status
+  }
+
+  async initialize(context?: EvaluationContext): Promise<void> {
+    this.overrides = readOverrides()
+    try {
+      localStorage.setItem(DEVTOOLS_MARKER_KEY, 'enabled')
+    } catch {}
+    await this.inner.initialize?.(context)
+  }
+
+  async onClose(): Promise<void> {
+    try {
+      localStorage.removeItem(DEVTOOLS_MARKER_KEY)
+    } catch {}
+    await this.inner.onClose?.()
+  }
+
+  onContextChange(oldContext: EvaluationContext, newContext: EvaluationContext): Promise<void> | void {
+    return this.inner.onContextChange?.(oldContext, newContext)
+  }
+
+  private resolveOverride<T>(flagKey: string, expectedTypes: DDFlagOverrideType[]): ResolutionDetails<T> | null {
+    const override = this.overrides[flagKey]
+    if (!override || !expectedTypes.includes(override.type)) {
+      return null
+    }
+    if (override.value === null || typeof override.value !== EXPECTED_JS_TYPES[override.type]) {
+      const msg = `[DatadogDevtools] override for '${flagKey}' declares type ${override.type} but value is ${typeof override.value} — override ignored`
+      console.warn(msg)
+      throw new TypeMismatchError(msg)
+    }
+    if (override.type === 'INTEGER' && !Number.isInteger(override.value)) {
+      const msg = `[DatadogDevtools] override for '${flagKey}' declares type INTEGER but value ${override.value} is not a whole number — override ignored`
+      console.warn(msg)
+      throw new TypeMismatchError(msg)
+    }
+    return { value: override.value as T, reason: 'STATIC', flagMetadata: { overridden: true } }
+  }
+
+  resolveBooleanEvaluation(
+    flagKey: string,
+    defaultValue: boolean,
+    context: EvaluationContext,
+    logger: Logger
+  ): ResolutionDetails<boolean> {
+    return this.resolveOverride<boolean>(flagKey, ['BOOLEAN']) ?? this.inner.resolveBooleanEvaluation(flagKey, defaultValue, context, logger)
+  }
+
+  resolveStringEvaluation(
+    flagKey: string,
+    defaultValue: string,
+    context: EvaluationContext,
+    logger: Logger
+  ): ResolutionDetails<string> {
+    return this.resolveOverride<string>(flagKey, ['STRING']) ?? this.inner.resolveStringEvaluation(flagKey, defaultValue, context, logger)
+  }
+
+  resolveNumberEvaluation(
+    flagKey: string,
+    defaultValue: number,
+    context: EvaluationContext,
+    logger: Logger
+  ): ResolutionDetails<number> {
+    return (
+      this.resolveOverride<number>(flagKey, ['INTEGER', 'NUMERIC']) ??
+      this.inner.resolveNumberEvaluation(flagKey, defaultValue, context, logger)
+    )
+  }
+
+  resolveObjectEvaluation<T extends JsonValue>(
+    flagKey: string,
+    defaultValue: T,
+    context: EvaluationContext,
+    logger: Logger
+  ): ResolutionDetails<T> {
+    return this.resolveOverride<T>(flagKey, ['JSON']) ?? this.inner.resolveObjectEvaluation(flagKey, defaultValue, context, logger)
+  }
+}

--- a/packages/browser/src/openfeature/devtools-provider.ts
+++ b/packages/browser/src/openfeature/devtools-provider.ts
@@ -21,10 +21,12 @@ interface DDFlagOverride {
 
 function readOverrides(): Record<string, DDFlagOverride> {
   try {
-    return JSON.parse(localStorage.getItem(OVERRIDES_KEY) ?? '{}') as Record<string, DDFlagOverride>
-  } catch {
-    return {}
-  }
+    const parsed = JSON.parse(localStorage.getItem(OVERRIDES_KEY) ?? '{}')
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, DDFlagOverride>
+    }
+  } catch {}
+  return {}
 }
 
 const EXPECTED_JS_TYPES: Record<DDFlagOverrideType, string> = {
@@ -94,8 +96,9 @@ export class DatadogDevtools implements Provider {
     if (!override || !expectedTypes.includes(override.type)) {
       return null
     }
-    if (override.value === null || typeof override.value !== EXPECTED_JS_TYPES[override.type]) {
-      const msg = `[DatadogDevtools] override for '${flagKey}' declares type ${override.type} but value is ${typeof override.value} — override ignored`
+    const actualType = override.value === null ? 'null' : typeof override.value
+    if (override.value === null || actualType !== EXPECTED_JS_TYPES[override.type]) {
+      const msg = `[DatadogDevtools] override for '${flagKey}' declares type ${override.type} but value is ${actualType} — override ignored`
       console.warn(msg)
       throw new TypeMismatchError(msg)
     }

--- a/packages/browser/test/openfeature/devtools-provider.spec.ts
+++ b/packages/browser/test/openfeature/devtools-provider.spec.ts
@@ -1,0 +1,397 @@
+import type { EvaluationContext, JsonValue, Logger, Provider, ResolutionDetails } from '@openfeature/web-sdk'
+import { OpenFeatureEventEmitter, TypeMismatchError } from '@openfeature/web-sdk'
+import { DatadogDevtools } from '../../src/openfeature/devtools-provider'
+
+const OVERRIDES_KEY = 'dd.dd_flag.overrides'
+const DEVTOOLS_MARKER_KEY = 'dd.dd_flag.devtools'
+
+const noopLogger = {} as Logger
+const emptyContext: EvaluationContext = {}
+
+function makeInner(overrides: Partial<Provider> = {}): jest.Mocked<Provider> {
+  return {
+    metadata: { name: 'mock-inner' },
+    runsOn: 'client',
+    hooks: [],
+    events: new OpenFeatureEventEmitter(),
+    initialize: jest.fn().mockResolvedValue(undefined),
+    onClose: jest.fn().mockResolvedValue(undefined),
+    onContextChange: jest.fn().mockResolvedValue(undefined),
+    resolveBooleanEvaluation: jest.fn().mockReturnValue({ value: false, reason: 'DEFAULT' }),
+    resolveStringEvaluation: jest.fn().mockReturnValue({ value: 'inner-default', reason: 'DEFAULT' }),
+    resolveNumberEvaluation: jest.fn().mockReturnValue({ value: 0, reason: 'DEFAULT' }),
+    resolveObjectEvaluation: jest.fn().mockReturnValue({ value: {}, reason: 'DEFAULT' }),
+    ...overrides,
+  } as jest.Mocked<Provider>
+}
+
+function setOverrides(overrides: Record<string, unknown>) {
+  localStorage.setItem(OVERRIDES_KEY, JSON.stringify(overrides))
+}
+
+describe('DatadogDevtools', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  describe('initialization', () => {
+    it('loads overrides from localStorage once on initialize', async () => {
+      setOverrides({ 'my-flag': { type: 'BOOLEAN', value: true } })
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      const getItemSpy = jest.spyOn(Storage.prototype, 'getItem')
+
+      await wrapper.initialize(emptyContext)
+      const readsAfterInit = getItemSpy.mock.calls.length
+
+      // Overwrite localStorage after init — should not affect in-memory overrides
+      localStorage.setItem(OVERRIDES_KEY, JSON.stringify({ 'my-flag': { type: 'BOOLEAN', value: false } }))
+
+      wrapper.resolveBooleanEvaluation('my-flag', false, emptyContext, noopLogger)
+      wrapper.resolveBooleanEvaluation('my-flag', false, emptyContext, noopLogger)
+      wrapper.resolveBooleanEvaluation('my-flag', false, emptyContext, noopLogger)
+
+      // No additional localStorage reads after init
+      expect(getItemSpy).toHaveBeenCalledTimes(readsAfterInit)
+      // And the cached value (true) is used, not the overwritten one (false)
+      expect(wrapper.resolveBooleanEvaluation('my-flag', false, emptyContext, noopLogger).value).toBe(true)
+
+      getItemSpy.mockRestore()
+    })
+
+    it('writes the devtools enablement marker to localStorage', async () => {
+      const wrapper = new DatadogDevtools(makeInner())
+      await wrapper.initialize(emptyContext)
+      expect(localStorage.getItem(DEVTOOLS_MARKER_KEY)).toBe('enabled')
+    })
+
+    it('delegates initialize to the inner provider with the same context', async () => {
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      const context = { targetingKey: 'user-1' }
+
+      await wrapper.initialize(context)
+
+      expect(inner.initialize).toHaveBeenCalledWith(context)
+    })
+
+    it('does not crash when localStorage is unavailable during initialize', async () => {
+      jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('storage unavailable')
+      })
+
+      const wrapper = new DatadogDevtools(makeInner())
+      await expect(wrapper.initialize(emptyContext)).resolves.toBeUndefined()
+
+      jest.restoreAllMocks()
+    })
+
+    it('falls back to empty overrides when localStorage contains malformed JSON', async () => {
+      localStorage.setItem(OVERRIDES_KEY, 'not-valid-json}}}')
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      await wrapper.initialize(emptyContext)
+
+      const result = wrapper.resolveBooleanEvaluation('my-flag', false, emptyContext, noopLogger)
+
+      // miss → delegates to inner
+      expect(inner.resolveBooleanEvaluation).toHaveBeenCalled()
+      expect(result).toEqual({ value: false, reason: 'DEFAULT' })
+    })
+  })
+
+  describe('lifecycle delegation', () => {
+    it('forwards onContextChange to inner provider', async () => {
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      const old = { targetingKey: 'user-1' }
+      const next = { targetingKey: 'user-2' }
+
+      await wrapper.onContextChange?.(old, next)
+
+      expect(inner.onContextChange).toHaveBeenCalledWith(old, next)
+    })
+
+    it('removes the devtools marker and calls inner onClose', async () => {
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      await wrapper.initialize(emptyContext)
+      expect(localStorage.getItem(DEVTOOLS_MARKER_KEY)).toBe('enabled')
+
+      await wrapper.onClose?.()
+
+      expect(localStorage.getItem(DEVTOOLS_MARKER_KEY)).toBeNull()
+      expect(inner.onClose).toHaveBeenCalled()
+    })
+
+    it('exposes inner provider hooks', () => {
+      const hooks = [{ name: 'my-hook' }] as any
+      const inner = makeInner({ hooks })
+      const wrapper = new DatadogDevtools(inner)
+      expect(wrapper.hooks).toBe(hooks)
+    })
+
+    it('exposes inner provider events', () => {
+      const events = new OpenFeatureEventEmitter()
+      const inner = makeInner({ events })
+      const wrapper = new DatadogDevtools(inner)
+      expect(wrapper.events).toBe(events)
+    })
+
+    it('exposes inner provider status', () => {
+      const inner = makeInner({ status: 'READY' as any })
+      const wrapper = new DatadogDevtools(inner)
+      expect(wrapper.status).toBe('READY')
+    })
+  })
+
+  describe('override hit — returns override, does not call inner', () => {
+    beforeEach(async () => {
+      setOverrides({
+        'bool-flag': { type: 'BOOLEAN', value: true },
+        'str-flag': { type: 'STRING', value: 'override-value' },
+        'int-flag': { type: 'INTEGER', value: 42 },
+        'num-flag': { type: 'NUMERIC', value: 3.14 },
+        'json-flag': { type: 'JSON', value: { nested: true } },
+      })
+    })
+
+    it('returns BOOLEAN override', async () => {
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      await wrapper.initialize(emptyContext)
+
+      const result = wrapper.resolveBooleanEvaluation('bool-flag', false, emptyContext, noopLogger)
+
+      expect(result).toEqual({ value: true, reason: 'STATIC', flagMetadata: { overridden: true } })
+      expect(inner.resolveBooleanEvaluation).not.toHaveBeenCalled()
+    })
+
+    it('returns STRING override', async () => {
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      await wrapper.initialize(emptyContext)
+
+      const result = wrapper.resolveStringEvaluation('str-flag', 'default', emptyContext, noopLogger)
+
+      expect(result).toEqual({ value: 'override-value', reason: 'STATIC', flagMetadata: { overridden: true } })
+      expect(inner.resolveStringEvaluation).not.toHaveBeenCalled()
+    })
+
+    it('returns INTEGER override', async () => {
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      await wrapper.initialize(emptyContext)
+
+      const result = wrapper.resolveNumberEvaluation('int-flag', 0, emptyContext, noopLogger)
+
+      expect(result).toEqual({ value: 42, reason: 'STATIC', flagMetadata: { overridden: true } })
+      expect(inner.resolveNumberEvaluation).not.toHaveBeenCalled()
+    })
+
+    it('returns NUMERIC override', async () => {
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      await wrapper.initialize(emptyContext)
+
+      const result = wrapper.resolveNumberEvaluation('num-flag', 0, emptyContext, noopLogger)
+
+      expect(result).toEqual({ value: 3.14, reason: 'STATIC', flagMetadata: { overridden: true } })
+      expect(inner.resolveNumberEvaluation).not.toHaveBeenCalled()
+    })
+
+    it('returns JSON override', async () => {
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      await wrapper.initialize(emptyContext)
+
+      const result = wrapper.resolveObjectEvaluation('json-flag', {}, emptyContext, noopLogger)
+
+      expect(result).toEqual({ value: { nested: true }, reason: 'STATIC', flagMetadata: { overridden: true } })
+      expect(inner.resolveObjectEvaluation).not.toHaveBeenCalled()
+    })
+
+    it('returns BOOLEAN override with value false (falsy)', async () => {
+      setOverrides({ 'bool-flag': { type: 'BOOLEAN', value: false } })
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      await wrapper.initialize(emptyContext)
+
+      const result = wrapper.resolveBooleanEvaluation('bool-flag', true, emptyContext, noopLogger)
+
+      expect(result).toEqual({ value: false, reason: 'STATIC', flagMetadata: { overridden: true } })
+      expect(inner.resolveBooleanEvaluation).not.toHaveBeenCalled()
+    })
+
+    it('returns NUMERIC override with value 0 (falsy)', async () => {
+      setOverrides({ 'num-flag': { type: 'NUMERIC', value: 0 } })
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      await wrapper.initialize(emptyContext)
+
+      const result = wrapper.resolveNumberEvaluation('num-flag', 99, emptyContext, noopLogger)
+
+      expect(result).toEqual({ value: 0, reason: 'STATIC', flagMetadata: { overridden: true } })
+      expect(inner.resolveNumberEvaluation).not.toHaveBeenCalled()
+    })
+
+    it('rejects JSON override with null value', async () => {
+      setOverrides({ 'json-flag': { type: 'JSON', value: null } })
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      await wrapper.initialize(emptyContext)
+
+      expect(() => wrapper.resolveObjectEvaluation('json-flag', {}, emptyContext, noopLogger)).toThrow()
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("'json-flag'"))
+      warnSpy.mockRestore()
+    })
+
+    it('handles multiple coexisting overrides independently', async () => {
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      await wrapper.initialize(emptyContext)
+
+      expect(wrapper.resolveBooleanEvaluation('bool-flag', false, emptyContext, noopLogger).value).toBe(true)
+      expect(wrapper.resolveStringEvaluation('str-flag', '', emptyContext, noopLogger).value).toBe('override-value')
+      expect(inner.resolveBooleanEvaluation).not.toHaveBeenCalled()
+      expect(inner.resolveStringEvaluation).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('override miss — delegates to inner provider', () => {
+    it('delegates boolean evaluation when no override exists', async () => {
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      await wrapper.initialize(emptyContext)
+
+      const result = wrapper.resolveBooleanEvaluation('unknown-flag', false, emptyContext, noopLogger)
+
+      expect(inner.resolveBooleanEvaluation).toHaveBeenCalledWith('unknown-flag', false, emptyContext, noopLogger)
+      expect(result).toEqual({ value: false, reason: 'DEFAULT' })
+    })
+
+    it('delegates string evaluation when no override exists', async () => {
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      await wrapper.initialize(emptyContext)
+
+      wrapper.resolveStringEvaluation('unknown-flag', 'default', emptyContext, noopLogger)
+
+      expect(inner.resolveStringEvaluation).toHaveBeenCalledWith('unknown-flag', 'default', emptyContext, noopLogger)
+    })
+
+    it('delegates number evaluation when no override exists', async () => {
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      await wrapper.initialize(emptyContext)
+
+      wrapper.resolveNumberEvaluation('unknown-flag', 0, emptyContext, noopLogger)
+
+      expect(inner.resolveNumberEvaluation).toHaveBeenCalledWith('unknown-flag', 0, emptyContext, noopLogger)
+    })
+
+    it('delegates object evaluation when no override exists', async () => {
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      await wrapper.initialize(emptyContext)
+
+      wrapper.resolveObjectEvaluation('unknown-flag', {}, emptyContext, noopLogger)
+
+      expect(inner.resolveObjectEvaluation).toHaveBeenCalledWith('unknown-flag', {}, emptyContext, noopLogger)
+    })
+
+    it('delegates when override type does not match the requested type', async () => {
+      // STRING override, but resolveBoolean is called — type mismatch at the selection level, not value level
+      setOverrides({ 'my-flag': { type: 'STRING', value: 'hello' } })
+      const inner = makeInner()
+      const wrapper = new DatadogDevtools(inner)
+      await wrapper.initialize(emptyContext)
+
+      wrapper.resolveBooleanEvaluation('my-flag', false, emptyContext, noopLogger)
+
+      expect(inner.resolveBooleanEvaluation).toHaveBeenCalled()
+    })
+
+    it('propagates inner provider errors on miss', async () => {
+      const inner = makeInner({
+        resolveBooleanEvaluation: jest.fn().mockImplementation(() => {
+          throw new Error('inner error')
+        }),
+      })
+      const wrapper = new DatadogDevtools(inner)
+      await wrapper.initialize(emptyContext)
+
+      expect(() => wrapper.resolveBooleanEvaluation('unknown-flag', false, emptyContext, noopLogger)).toThrow(
+        'inner error'
+      )
+    })
+  })
+
+  describe('type validation — TypeMismatchError', () => {
+    let warnSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      warnSpy.mockRestore()
+    })
+
+    it('throws TypeMismatchError and warns for BOOLEAN override with non-boolean value', async () => {
+      setOverrides({ 'my-flag': { type: 'BOOLEAN', value: 'yes' } })
+      const wrapper = new DatadogDevtools(makeInner())
+      await wrapper.initialize(emptyContext)
+
+      expect(() => wrapper.resolveBooleanEvaluation('my-flag', false, emptyContext, noopLogger)).toThrow(TypeMismatchError)
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("'my-flag'"))
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('override ignored'))
+    })
+
+    it('throws TypeMismatchError and warns for STRING override with non-string value', async () => {
+      setOverrides({ 'my-flag': { type: 'STRING', value: 123 } })
+      const wrapper = new DatadogDevtools(makeInner())
+      await wrapper.initialize(emptyContext)
+
+      expect(() => wrapper.resolveStringEvaluation('my-flag', 'default', emptyContext, noopLogger)).toThrow(TypeMismatchError)
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("'my-flag'"))
+    })
+
+    it('throws TypeMismatchError and warns for INTEGER override with non-number value', async () => {
+      setOverrides({ 'my-flag': { type: 'INTEGER', value: 'not-a-number' } })
+      const wrapper = new DatadogDevtools(makeInner())
+      await wrapper.initialize(emptyContext)
+
+      expect(() => wrapper.resolveNumberEvaluation('my-flag', 0, emptyContext, noopLogger)).toThrow(TypeMismatchError)
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("'my-flag'"))
+    })
+
+    it('throws TypeMismatchError and warns for INTEGER override with float value', async () => {
+      setOverrides({ 'my-flag': { type: 'INTEGER', value: 3.14 } })
+      const wrapper = new DatadogDevtools(makeInner())
+      await wrapper.initialize(emptyContext)
+
+      expect(() => wrapper.resolveNumberEvaluation('my-flag', 0, emptyContext, noopLogger)).toThrow(TypeMismatchError)
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not a whole number'))
+    })
+
+    it('throws TypeMismatchError and warns for NUMERIC override with non-number value', async () => {
+      setOverrides({ 'my-flag': { type: 'NUMERIC', value: true } })
+      const wrapper = new DatadogDevtools(makeInner())
+      await wrapper.initialize(emptyContext)
+
+      expect(() => wrapper.resolveNumberEvaluation('my-flag', 0, emptyContext, noopLogger)).toThrow(TypeMismatchError)
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("'my-flag'"))
+    })
+
+    it('throws TypeMismatchError and warns for JSON override with non-object value', async () => {
+      setOverrides({ 'my-flag': { type: 'JSON', value: 'not-an-object' } })
+      const wrapper = new DatadogDevtools(makeInner())
+      await wrapper.initialize(emptyContext)
+
+      expect(() => wrapper.resolveObjectEvaluation('my-flag', {}, emptyContext, noopLogger)).toThrow(TypeMismatchError)
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("'my-flag'"))
+    })
+  })
+})

--- a/packages/browser/test/openfeature/devtools-provider.spec.ts
+++ b/packages/browser/test/openfeature/devtools-provider.spec.ts
@@ -98,6 +98,20 @@ describe('DatadogDevtools', () => {
       expect(inner.resolveBooleanEvaluation).toHaveBeenCalled()
       expect(result).toEqual({ value: false, reason: 'DEFAULT' })
     })
+
+    it('falls back to empty overrides when localStorage contains valid JSON but not an object', async () => {
+      for (const value of ['null', '"a string"', '[1,2,3]', '42']) {
+        localStorage.setItem(OVERRIDES_KEY, value)
+        const inner = makeInner()
+        const wrapper = new DatadogDevtools(inner)
+        await wrapper.initialize(emptyContext)
+
+        wrapper.resolveBooleanEvaluation('my-flag', false, emptyContext, noopLogger)
+
+        expect(inner.resolveBooleanEvaluation).toHaveBeenCalled()
+        localStorage.clear()
+      }
+    })
   })
 
   describe('lifecycle delegation', () => {

--- a/packages/browser/test/openfeature/devtools-provider.spec.ts
+++ b/packages/browser/test/openfeature/devtools-provider.spec.ts
@@ -1,5 +1,5 @@
-import type { EvaluationContext, JsonValue, Logger, Provider, ResolutionDetails } from '@openfeature/web-sdk'
-import { OpenFeatureEventEmitter, TypeMismatchError } from '@openfeature/web-sdk'
+import type { EvaluationContext, Hook, Logger, Provider } from '@openfeature/web-sdk'
+import { OpenFeatureEventEmitter, ProviderStatus, TypeMismatchError } from '@openfeature/web-sdk'
 import { DatadogDevtools } from '../../src/openfeature/devtools-provider'
 
 const OVERRIDES_KEY = 'dd.dd_flag.overrides'
@@ -125,7 +125,7 @@ describe('DatadogDevtools', () => {
     })
 
     it('exposes inner provider hooks', () => {
-      const hooks = [{ name: 'my-hook' }] as any
+      const hooks: Hook[] = []
       const inner = makeInner({ hooks })
       const wrapper = new DatadogDevtools(inner)
       expect(wrapper.hooks).toBe(hooks)
@@ -139,9 +139,9 @@ describe('DatadogDevtools', () => {
     })
 
     it('exposes inner provider status', () => {
-      const inner = makeInner({ status: 'READY' as any })
+      const inner = makeInner({ status: ProviderStatus.READY })
       const wrapper = new DatadogDevtools(inner)
-      expect(wrapper.status).toBe('READY')
+      expect(wrapper.status).toBe(ProviderStatus.READY)
     })
   })
 
@@ -344,7 +344,9 @@ describe('DatadogDevtools', () => {
       const wrapper = new DatadogDevtools(makeInner())
       await wrapper.initialize(emptyContext)
 
-      expect(() => wrapper.resolveBooleanEvaluation('my-flag', false, emptyContext, noopLogger)).toThrow(TypeMismatchError)
+      expect(() => wrapper.resolveBooleanEvaluation('my-flag', false, emptyContext, noopLogger)).toThrow(
+        TypeMismatchError
+      )
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("'my-flag'"))
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('override ignored'))
     })
@@ -354,7 +356,9 @@ describe('DatadogDevtools', () => {
       const wrapper = new DatadogDevtools(makeInner())
       await wrapper.initialize(emptyContext)
 
-      expect(() => wrapper.resolveStringEvaluation('my-flag', 'default', emptyContext, noopLogger)).toThrow(TypeMismatchError)
+      expect(() => wrapper.resolveStringEvaluation('my-flag', 'default', emptyContext, noopLogger)).toThrow(
+        TypeMismatchError
+      )
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("'my-flag'"))
     })
 


### PR DESCRIPTION
## Context

The Datadog Configurator currently applies flag overrides through wrapper functions in web-ui that short-circuit before OpenFeature runs. This means hooks never fire for overridden flags, there's no single observation point to record what flags a page evaluated, and customers using the SDK directly have no override mechanism at all.

This PR moves overrides inside the OpenFeature chain by introducing `DatadogDevtools` — a provider wrapper that sits in front of any inner provider and intercepts evaluations where an override exists. The core `DatadogProvider` is untouched.

This is part of the Browser Extension Project: [RFC](https://docs.google.com/document/d/1bEZqKgT_sX2gVVdq8bR8BlelkcFzrcsocNfO0Lj9_38/edit?pli=1&tab=t.0)

## What changed

**`DatadogDevtools`** — a new provider wrapper exported from `@datadog/openfeature-browser`:
- Wraps any OpenFeature provider — no `MultiProvider` dependency required
- Loads overrides **once on `initialize()`** from `localStorage['dd.dd_flag.overrides']` into memory — zero localStorage reads per flag evaluation
- On override hit: returns the value with `flagMetadata.overridden = true` and `reason: STATIC`, does not call the inner provider
- On override miss: delegates directly to the inner provider unchanged
- Supports all 5 flag types: `BOOLEAN`, `STRING`, `INTEGER`, `NUMERIC`, `JSON`
- Runtime type validation — throws `TypeMismatchError` and `console.warn`s if the declared type and actual value type don't match, so bad overrides are visible rather than silently falling through to the default
- Writes an enablement marker (`dd.dd_flag.devtools = "enabled"`) on `initialize()` so the browser extension can detect devtools are active; removes it on `onClose()`
- Forwards `hooks`, `events`, `status`, `onContextChange`, and `onClose` to the inner provider

**Tests** — 31 tests covering: all 5 override types, falsy values (`false`, `0`), miss/delegation for all 4 resolve methods, cross-type delegation, `TypeMismatchError` + `console.warn` for all mismatch cases, `null` JSON value rejection, overrides loaded exactly once (localStorage read count asserted), marker written/removed, lifecycle methods delegated, inner provider errors bubbling through, malformed localStorage.

## How customers use this

**Production — no change needed:**
```ts
import { DatadogProvider } from '@datadog/openfeature-browser'

await OpenFeature.setProvider(new DatadogProvider(config))
```

**Development — wrap the provider:**
```ts
import { DatadogProvider, DatadogDevtools } from '@datadog/openfeature-browser'

await OpenFeature.setProvider(new DatadogDevtools(new DatadogProvider(config)))
```

No `MultiProvider`, no extra dependencies. When dev tools are not needed, `DatadogDevtools` is absent from the bundle entirely.

Overrides live in `localStorage['dd.dd_flag.overrides']` — written by the browser extension in practice, but settable manually for testing:

```js
localStorage.setItem('dd.dd_flag.overrides', JSON.stringify({
  'my-boolean-flag': { type: 'BOOLEAN', value: true },
  'app-theme':        { type: 'STRING',  value: 'dark' },
  'rollout-percent':  { type: 'NUMERIC', value: 100 },
}))
```

Overrides persist across reloads. Within a session they're loaded once at startup — mid-session `localStorage` changes take effect on the next reload. Overridden evaluations return `flagMetadata.overridden === true`.

## Test plan
- [ ] Override hit: set `dd.dd_flag.overrides`, evaluate flag — resolves to override, inner provider not called
- [ ] Override miss: no entry — delegates to inner provider normally
- [ ] Type mismatch: `{ type: 'BOOLEAN', value: 'yes' }` — `console.warn` fires, falls back to default
- [ ] `null` JSON value: `{ type: 'JSON', value: null }` — rejected, `console.warn` fires
- [ ] Falsy values: `{ type: 'BOOLEAN', value: false }` and `{ type: 'NUMERIC', value: 0 }` — returned correctly
- [ ] Enablement marker: `localStorage.getItem('dd.dd_flag.devtools') === 'enabled'` after init
- [ ] `yarn workspace @datadog/openfeature-browser test` — all 31 tests pass
