### PR TITLE
fix(core): serialize precomputed.response in configurationToString

### DIFF
--- a/packages/core/src/configuration/wire.test.ts
+++ b/packages/core/src/configuration/wire.test.ts
@@ -1,0 +1,59 @@
+import type { FlagsConfiguration } from './configuration'
+import { configurationFromString, configurationToString } from './wire'
+
+const configuration: FlagsConfiguration = {
+  precomputed: {
+    response: {
+      data: {
+        attributes: {
+          createdAt: '2026-07-06T23:01:56.822Z',
+          flags: {
+            'my-flag': {
+              allocationKey: 'alloc-1',
+              variationKey: 'true',
+              variationType: 'boolean',
+              variationValue: true,
+              reason: 'STATIC',
+              doLog: true,
+              extraLogging: {},
+            },
+          },
+        },
+      },
+    },
+    context: { targetingKey: 'user-1', country: 'US' },
+  },
+}
+
+describe('configuration wire', () => {
+  it('round-trips a precomputed configuration', () => {
+    const restored = configurationFromString(configurationToString(configuration))
+
+    expect(restored).toEqual(configuration)
+  })
+
+  it('keeps flags readable after a round-trip', () => {
+    const restored = configurationFromString(configurationToString(configuration))
+
+    expect(restored.precomputed?.response.data.attributes.flags['my-flag'].variationValue).toBe(
+      true,
+    )
+  })
+
+  it('serializes precomputed.response as a stringified response object, not the whole precomputed', () => {
+    const wire = JSON.parse(configurationToString(configuration))
+
+    // `precomputed.response` on the wire must be the response only, so parsing it yields
+    // the response object (regression guard: it previously stringified the whole
+    // precomputed object, double-nesting the response and losing the flags).
+    expect(JSON.parse(wire.precomputed.response)).toEqual(configuration.precomputed?.response)
+  })
+
+  it('returns an empty configuration for an unknown version', () => {
+    expect(configurationFromString(JSON.stringify({ version: 2 }))).toEqual({})
+  })
+
+  it('returns an empty configuration for malformed input', () => {
+    expect(configurationFromString('not json')).toEqual({})
+  })
+})

--- a/packages/core/src/configuration/wire.test.ts
+++ b/packages/core/src/configuration/wire.test.ts
@@ -35,9 +35,7 @@ describe('configuration wire', () => {
   it('keeps flags readable after a round-trip', () => {
     const restored = configurationFromString(configurationToString(configuration))
 
-    expect(restored.precomputed?.response.data.attributes.flags['my-flag'].variationValue).toBe(
-      true,
-    )
+    expect(restored.precomputed?.response.data.attributes.flags['my-flag'].variationValue).toBe(true)
   })
 
   it('serializes precomputed.response as a stringified response object, not the whole precomputed', () => {

--- a/packages/core/src/configuration/wire.ts
+++ b/packages/core/src/configuration/wire.ts
@@ -50,7 +50,7 @@ export function configurationToString(configuration: FlagsConfiguration): string
   if (configuration.precomputed) {
     wire.precomputed = {
       ...configuration.precomputed,
-      response: JSON.stringify(configuration.precomputed),
+      response: JSON.stringify(configuration.precomputed.response),
     }
   }
 


### PR DESCRIPTION
## Motivation

`configurationToString` does not round-trip: serializing a `FlagsConfiguration` and parsing it back with `configurationFromString` loses all flags. Found while evaluating reuse of `@datadog/flagging-core`'s wire helpers from the `dd-sdk-reactnative` SDK.

## Changes

`configurationToString` stringified the **entire** `precomputed` object into the wire's `precomputed.response` field instead of just `precomputed.response`:

```ts
// before
response: JSON.stringify(configuration.precomputed),
// after
response: JSON.stringify(configuration.precomputed.response),
```

Because of this, `configurationFromString` (which parses `wire.precomputed.response` back into `response`) nested the real response one level too deep — `precomputed.response` became `{ response, context, fetchedAt }`, so `precomputed.response.data` was `undefined` and every flag was lost on a serialize→parse cycle.

The CDN-produced wire is unaffected (it stringifies `response` correctly); the bug only manifests when `configurationToString` produces the wire (persisting or re-serializing a config).

The fix mirrors `configurationFromString`. Adds `wire.test.ts` (the file's first test) covering:
- round-trip identity
- flags still readable after a round-trip
- the serialized `precomputed.response` shape (regression guard)
- version and malformed-input fallbacks

Verified the new test fails against the old code (3 targeted failures) and passes with the fix.

## Test instructions

`yarn --cwd packages/core test` — 5 suites / 33 tests pass. `yarn lint` and `yarn --cwd packages/core typecheck` are clean.

## Checklist

- [ ] Updated Documentation
- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
