### PR TITLE
👷 chore(release): @datadog/flagging-core@2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@
 
 ---
 
+## @datadog/flagging-core@2.0.0
+
+**Breaking Changes:**
+
+- Major version bump. `@datadog/flagging-core` cannot be safely updated within the 1.x range — existing `^1.2.1` consumers would pull new 1.x versions and risk version skew — so these additions ship as `2.0.0`.
+
+**Features:**
+
+- refactor: extract rules-based UFC evaluator into `@datadog/flagging-core` ([#332](https://github.com/DataDog/openfeature-js-client/pull/332))
+- feat: adopt js-core 0.0.3 (TimeStamp types, monitor, util) ([#308](https://github.com/DataDog/openfeature-js-client/pull/308))
+
+**Bug Fixes:**
+
+- fix(core): serialize precomputed.response in configurationToString ([#331](https://github.com/DataDog/openfeature-js-client/pull/331))
+
+**Internal Changes:**
+
+- Align Node.js flagevaluation EVP metadata ([#317](https://github.com/DataDog/openfeature-js-client/pull/317))
+
 ## @datadog/openfeature-browser@1.2.3
 
 **Features:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,7 +252,10 @@ Since this project uses **independent versioning**:
 - Internal dependencies are pinned to exact versions (configured via `command.version.exact` in `lerna.json`)
 - Version commits and tags are created per package (e.g., `@datadog/openfeature-node-server@1.3.0`)
 
-> ⚠️ **Warning:** `@datadog/flagging-core` cannot be safely updated within the 1.x range. Users on `openfeature-node-server@1.2.1` have a `^1.2.1` constraint and would pull any new 1.x version, causing version skew. A major bump to `2.0.0` is required for any future `flagging-core` changes.
+> ⚠️ **Version policy for `@datadog/flagging-core`:** Internal dependencies are pinned to **exact** versions (enforced by `scripts/internal-deps-validate.sh`), so our packages never pull a core update implicitly. From `2.0.0` onward, `flagging-core` follows normal semver — minor/patch for backward-compatible changes, major for breaking ones. Two rules still apply:
+>
+> 1. **Do not publish new `1.x` versions of `flagging-core`.** Legacy consumers still on `^1.2.1` would pull them and risk version skew; the `2.0.0` major bump exists to cap those consumers below `2.x`.
+> 2. **Bumping core does not reach dependents automatically.** Because `openfeature-browser` and `openfeature-node-server` pin core exactly, you must update each dependent's pin and re-release it (see [Step 2](#step-2-pin-internal-dependencies)) for consumers to pick up the new core.
 
 ### Automated Release Workflow Details
 

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@datadog/browser-core": "^6.33.0",
-    "@datadog/flagging-core": "1.2.1",
+    "@datadog/flagging-core": "2.0.0",
     "@datadog/js-core": "0.0.3"
   },
   "peerDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/flagging-core",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Runtime-agnostic flag-evaluation logic for Datadog Flagging",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -36,7 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@datadog/flagging-core": "1.2.1",
+    "@datadog/flagging-core": "2.0.0",
     "@datadog/js-core": "0.0.3"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -659,7 +659,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/flagging-core@npm:1.2.1, @datadog/flagging-core@workspace:packages/core":
+"@datadog/flagging-core@npm:2.0.0, @datadog/flagging-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@datadog/flagging-core@workspace:packages/core"
   dependencies:
@@ -689,7 +689,7 @@ __metadata:
   resolution: "@datadog/openfeature-browser@workspace:packages/browser"
   dependencies:
     "@datadog/browser-core": "npm:^6.33.0"
-    "@datadog/flagging-core": "npm:1.2.1"
+    "@datadog/flagging-core": "npm:2.0.0"
     "@datadog/js-core": "npm:0.0.3"
     "@openfeature/core": "npm:^1.9.2"
     "@openfeature/web-sdk": "npm:^1.5.0"
@@ -740,7 +740,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/openfeature-node-server@workspace:packages/node-server"
   dependencies:
-    "@datadog/flagging-core": "npm:1.2.1"
+    "@datadog/flagging-core": "npm:2.0.0"
     "@datadog/js-core": "npm:0.0.3"
     "@openfeature/core": "npm:1.9.2"
     "@openfeature/server-sdk": "npm:1.20.2"


### PR DESCRIPTION
## What
- `flagging-core` `1.2.1` → `2.0.0` (major, per CONTRIBUTING version policy)
- Repoints `node-server` / `browser` internal core pins to `2.0.0` (keeps the workspace buildable/consistent; neither is published this cycle)
- CHANGELOG entry for `@datadog/flagging-core@2.0.0`
- Rewrote the stale `flagging-core` version-policy warning in CONTRIBUTING.md

## Validation (local)
- `internal-deps-validate.sh` ✅ · `versions-validate.sh` ✅
- typecheck (all 3) ✅ · `BUILD_MODE=release yarn build` (all 3) ✅ · core tests 39/39 ✅

## Publish
Only `flagging-core` publishes this cycle, via the `@datadog/flagging-core@2.0.0` GitHub Release (created separately — triggers `release.yaml`). node-server/browser are **not** published; their pins move to `2.0.0` on `main` for a consistent tree and the next node-server release.