### PR TITLE
Release canonical evaluator patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 ---
 
+## @datadog/flagging-core@2.0.1, @datadog/openfeature-browser@1.2.4, @datadog/openfeature-node-server@2.0.1
+
+**Bug Fixes:**
+
+- Align shared UFC evaluation reasons and malformed-configuration isolation with the canonical cross-SDK fixtures ([#275](https://github.com/DataDog/openfeature-js-client/pull/275)) [BROWSER] [NODE-SERVER]
+
+**Internal Changes:**
+
+- Source evaluator regression coverage from `DataDog/ffe-system-test-data` ([#275](https://github.com/DataDog/openfeature-js-client/pull/275)) [BROWSER] [NODE-SERVER]
+
 ## @datadog/flagging-core@2.0.0
 
 **Breaking Changes:**

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-browser",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Browser-specific bindings for OpenFeature (wraps @datadog/openfeature-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@datadog/browser-core": "^6.33.0",
-    "@datadog/flagging-core": "2.0.0",
+    "@datadog/flagging-core": "2.0.1",
     "@datadog/js-core": "0.0.3"
   },
   "peerDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/flagging-core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Runtime-agnostic flag-evaluation logic for Datadog Flagging",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-node-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Node.js server bindings for OpenFeature (wraps @datadog/flagging-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",
@@ -36,7 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@datadog/flagging-core": "2.0.0",
+    "@datadog/flagging-core": "2.0.1",
     "@datadog/js-core": "0.0.3"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -659,7 +659,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/flagging-core@npm:2.0.0, @datadog/flagging-core@workspace:packages/core":
+"@datadog/flagging-core@npm:2.0.1, @datadog/flagging-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@datadog/flagging-core@workspace:packages/core"
   dependencies:
@@ -689,7 +689,7 @@ __metadata:
   resolution: "@datadog/openfeature-browser@workspace:packages/browser"
   dependencies:
     "@datadog/browser-core": "npm:^6.33.0"
-    "@datadog/flagging-core": "npm:2.0.0"
+    "@datadog/flagging-core": "npm:2.0.1"
     "@datadog/js-core": "npm:0.0.3"
     "@openfeature/core": "npm:^1.9.2"
     "@openfeature/web-sdk": "npm:^1.5.0"
@@ -740,7 +740,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/openfeature-node-server@workspace:packages/node-server"
   dependencies:
-    "@datadog/flagging-core": "npm:2.0.0"
+    "@datadog/flagging-core": "npm:2.0.1"
     "@datadog/js-core": "npm:0.0.3"
     "@openfeature/core": "npm:1.9.2"
     "@openfeature/server-sdk": "npm:1.20.2"


### PR DESCRIPTION
## Motivation

PR #275 moved the canonical UFC evaluator behavior and fixture coverage into `@datadog/flagging-core`. The shared core package and both consumers need coordinated patch releases so Node.js and browser users receive the corrected evaluation reasons and malformed-configuration handling.

## Changes

- Bump `@datadog/flagging-core` from `2.0.0` to `2.0.1`.
- Bump `@datadog/openfeature-browser` from `1.2.3` to `1.2.4`.
- Bump `@datadog/openfeature-node-server` from `2.0.0` to `2.0.1`.
- Pin both consumers to the exact `@datadog/flagging-core@2.0.1` version and update the lockfile.
- Document the canonical evaluator fixes and shared fixture coverage in the changelog.

## Decisions

- Release all three affected packages because the implementation lives in core and internal package dependencies are intentionally exact.
- Keep independent package versions and tags rather than creating a unified version.
- After merge, publish in dependency order: core, browser, then Node.js.

## Validation

- `bash scripts/internal-deps-validate.sh`
- `bash scripts/versions-validate.sh`
- `yarn licenses:validate`
- `yarn lint`
- `yarn format:check`
- `BUILD_MODE=release yarn build`
- `yarn typecheck` (after the core declaration build)
- `yarn test` (457 tests across 22 suites)
- `yarn test:browser-install`
- `yarn test:node-install` (7/7 consumer checks)
- `yarn test:node-install:with-of` (7/7 consumer checks)
- `yarn lerna run pack --stream`

All validation ran with Node.js 24.16.0, matching the repository's Node 24 CI target.
