### PR TITLE
fix(node): remove browser SDK dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,6 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@datadog/js-core": "0.0.3",
     "spark-md5": "^3.0.2"
   }
 }

--- a/packages/core/src/configuration/configuration.ts
+++ b/packages/core/src/configuration/configuration.ts
@@ -1,5 +1,5 @@
-import type { TimeStamp } from '@datadog/js-core/time'
 import type { EvaluationContext, FlagValueType, JsonValue, ResolutionReason } from '@openfeature/core'
+import type { TimeStamp } from '../time'
 
 /**
  * Internal flags configuration for DatadogProvider.

--- a/packages/core/src/configuration/exposureEvent.types.ts
+++ b/packages/core/src/configuration/exposureEvent.types.ts
@@ -1,5 +1,5 @@
-import type { TimeStamp } from '@datadog/js-core/time'
 import type { EvaluationContext } from '@openfeature/core'
+import type { TimeStamp } from '../time'
 
 export interface ExposureEvent {
   allocation: {

--- a/packages/core/src/configuration/flagEvaluationAggregator.ts
+++ b/packages/core/src/configuration/flagEvaluationAggregator.ts
@@ -1,7 +1,6 @@
-import type { TimeStamp } from '@datadog/js-core/time'
-import { timeStampNow } from '@datadog/js-core/time'
 import type { EvaluationContext, EvaluationContextValue, EvaluationDetails, FlagValue } from '@openfeature/core'
 import { getMD5Hash } from '../obfuscation'
+import type { TimeStamp } from '../time'
 import { createFlagEvaluationEvent } from './flagEvaluationEvent'
 import type { FlagEvaluationEvent } from './flagEvaluationEvent.types'
 
@@ -84,7 +83,7 @@ export class FlagEvaluationAggregator {
       return
     }
 
-    const flushTimestamp = timeStampNow()
+    const flushTimestamp = new Date().getTime() as TimeStamp
     const events = Array.from(this.aggregatedData.values()).map((data) =>
       createFlagEvaluationEvent(data, flushTimestamp)
     )
@@ -118,7 +117,7 @@ export class FlagEvaluationAggregator {
 
 function getEvaluationTimestamp<T extends FlagValue>(details: EvaluationDetails<T>): TimeStamp {
   const metadataTimestamp = details.flagMetadata?.[EVALUATION_TIMESTAMP_METADATA_KEY]
-  return Number.isFinite(metadataTimestamp) ? (metadataTimestamp as TimeStamp) : timeStampNow()
+  return Number.isFinite(metadataTimestamp) ? (metadataTimestamp as TimeStamp) : (new Date().getTime() as TimeStamp)
 }
 
 function isRuntimeDefaultUsed<T extends FlagValue>(details: EvaluationDetails<T>): boolean {

--- a/packages/core/src/configuration/flagEvaluationAggregator.ts
+++ b/packages/core/src/configuration/flagEvaluationAggregator.ts
@@ -1,6 +1,6 @@
 import type { EvaluationContext, EvaluationContextValue, EvaluationDetails, FlagValue } from '@openfeature/core'
 import { getMD5Hash } from '../obfuscation'
-import type { TimeStamp } from '../time'
+import { type TimeStamp, timeStampNow } from '../time'
 import { createFlagEvaluationEvent } from './flagEvaluationEvent'
 import type { FlagEvaluationEvent } from './flagEvaluationEvent.types'
 
@@ -83,7 +83,7 @@ export class FlagEvaluationAggregator {
       return
     }
 
-    const flushTimestamp = new Date().getTime() as TimeStamp
+    const flushTimestamp = timeStampNow()
     const events = Array.from(this.aggregatedData.values()).map((data) =>
       createFlagEvaluationEvent(data, flushTimestamp)
     )
@@ -117,7 +117,7 @@ export class FlagEvaluationAggregator {
 
 function getEvaluationTimestamp<T extends FlagValue>(details: EvaluationDetails<T>): TimeStamp {
   const metadataTimestamp = details.flagMetadata?.[EVALUATION_TIMESTAMP_METADATA_KEY]
-  return Number.isFinite(metadataTimestamp) ? (metadataTimestamp as TimeStamp) : (new Date().getTime() as TimeStamp)
+  return Number.isFinite(metadataTimestamp) ? (metadataTimestamp as TimeStamp) : timeStampNow()
 }
 
 function isRuntimeDefaultUsed<T extends FlagValue>(details: EvaluationDetails<T>): boolean {

--- a/packages/core/src/configuration/flagEvaluationEvent.ts
+++ b/packages/core/src/configuration/flagEvaluationEvent.ts
@@ -1,5 +1,5 @@
-import type { TimeStamp } from '@datadog/js-core/time'
 import type { EvaluationContextValue } from '@openfeature/core'
+import type { TimeStamp } from '../time'
 import type { FlagEvaluationEvent } from './flagEvaluationEvent.types'
 
 interface FlagEvaluationAggregationData {

--- a/packages/core/src/configuration/flagEvaluationEvent.types.ts
+++ b/packages/core/src/configuration/flagEvaluationEvent.types.ts
@@ -1,5 +1,5 @@
-import type { TimeStamp } from '@datadog/js-core/time'
 import type { EvaluationContextValue } from '@openfeature/core'
+import type { TimeStamp } from '../time'
 
 export interface FlagEvaluationEvent {
   flag: {

--- a/packages/core/src/configuration/wire.ts
+++ b/packages/core/src/configuration/wire.ts
@@ -1,5 +1,5 @@
-import type { TimeStamp } from '@datadog/js-core/time'
 import type { EvaluationContext } from '@openfeature/core'
+import type { TimeStamp } from '../time'
 import type { FlagsConfiguration } from './configuration'
 
 type ConfigurationWire = {

--- a/packages/core/src/evaluation/evaluateForSubject.ts
+++ b/packages/core/src/evaluation/evaluateForSubject.ts
@@ -1,6 +1,6 @@
 import type { ErrorCode, EvaluationContext, FlagValueType, Logger, ResolutionDetails } from '@openfeature/core'
 import type { FlagTypeToValue, PrecomputedFlagMetadata } from '../configuration'
-import type { TimeStamp } from '../time'
+import { type TimeStamp, timeStampNow } from '../time'
 import { TargetingKeyMissingError } from './errors'
 import { createEvaluationTimestampMetadata } from './evaluationMetadata'
 import { matchesShard } from './matchesShard'
@@ -14,7 +14,7 @@ export function evaluateForSubject<T extends FlagValueType>(
   subjectAttributes: EvaluationContext,
   defaultValue: FlagTypeToValue<T>,
   logger: Logger,
-  evaluationTimestampMs: TimeStamp = new Date().getTime() as TimeStamp
+  evaluationTimestampMs: TimeStamp = timeStampNow()
 ): ResolutionDetails<FlagTypeToValue<T>> {
   if (!flag.enabled) {
     logger.debug(`returning default assignment because flag is disabled`, {

--- a/packages/core/src/evaluation/evaluateForSubject.ts
+++ b/packages/core/src/evaluation/evaluateForSubject.ts
@@ -1,7 +1,6 @@
-import type { TimeStamp } from '@datadog/js-core/time'
-import { timeStampNow } from '@datadog/js-core/time'
 import type { ErrorCode, EvaluationContext, FlagValueType, Logger, ResolutionDetails } from '@openfeature/core'
 import type { FlagTypeToValue, PrecomputedFlagMetadata } from '../configuration'
+import type { TimeStamp } from '../time'
 import { TargetingKeyMissingError } from './errors'
 import { createEvaluationTimestampMetadata } from './evaluationMetadata'
 import { matchesShard } from './matchesShard'
@@ -15,7 +14,7 @@ export function evaluateForSubject<T extends FlagValueType>(
   subjectAttributes: EvaluationContext,
   defaultValue: FlagTypeToValue<T>,
   logger: Logger,
-  evaluationTimestampMs: TimeStamp = timeStampNow()
+  evaluationTimestampMs: TimeStamp = new Date().getTime() as TimeStamp
 ): ResolutionDetails<FlagTypeToValue<T>> {
   if (!flag.enabled) {
     logger.debug(`returning default assignment because flag is disabled`, {

--- a/packages/core/src/evaluation/evaluation.ts
+++ b/packages/core/src/evaluation/evaluation.ts
@@ -1,6 +1,6 @@
 import type { ErrorCode, EvaluationContext, FlagValueType, Logger, ResolutionDetails } from '@openfeature/core'
 import type { FlagTypeToValue } from '../configuration'
-import type { TimeStamp } from '../time'
+import { timeStampNow } from '../time'
 import { TargetingKeyMissingError } from './errors'
 import { evaluateForSubject } from './evaluateForSubject'
 import { createEvaluationTimestampMetadata } from './evaluationMetadata'
@@ -14,7 +14,7 @@ export function evaluateRulesBasedConfiguration<T extends FlagValueType>(
   context: EvaluationContext,
   logger: Logger
 ): ResolutionDetails<FlagTypeToValue<T>> {
-  const evaluationTimestampMs = new Date().getTime() as TimeStamp
+  const evaluationTimestampMs = timeStampNow()
 
   if (!config) {
     return {

--- a/packages/core/src/evaluation/evaluation.ts
+++ b/packages/core/src/evaluation/evaluation.ts
@@ -1,6 +1,6 @@
-import { timeStampNow } from '@datadog/js-core/time'
 import type { ErrorCode, EvaluationContext, FlagValueType, Logger, ResolutionDetails } from '@openfeature/core'
 import type { FlagTypeToValue } from '../configuration'
+import type { TimeStamp } from '../time'
 import { TargetingKeyMissingError } from './errors'
 import { evaluateForSubject } from './evaluateForSubject'
 import { createEvaluationTimestampMetadata } from './evaluationMetadata'
@@ -14,7 +14,7 @@ export function evaluateRulesBasedConfiguration<T extends FlagValueType>(
   context: EvaluationContext,
   logger: Logger
 ): ResolutionDetails<FlagTypeToValue<T>> {
-  const evaluationTimestampMs = timeStampNow()
+  const evaluationTimestampMs = new Date().getTime() as TimeStamp
 
   if (!config) {
     return {

--- a/packages/core/src/evaluation/evaluationMetadata.ts
+++ b/packages/core/src/evaluation/evaluationMetadata.ts
@@ -1,5 +1,5 @@
-import type { TimeStamp } from '@datadog/js-core/time'
 import type { PrecomputedFlagMetadata } from '../configuration'
+import type { TimeStamp } from '../time'
 
 export function createEvaluationTimestampMetadata(evaluationTimestampMs: TimeStamp): PrecomputedFlagMetadata {
   return { __dd_eval_timestamp_ms: evaluationTimestampMs } as PrecomputedFlagMetadata

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export * from './cache'
 export * from './configuration'
 export * from './evaluation'
 export * from './obfuscation'
+export * from './time'
 
 // Build environment placeholder for testing
 const _SDK_VERSION = __BUILD_ENV__SDK_VERSION__

--- a/packages/core/src/time.ts
+++ b/packages/core/src/time.ts
@@ -1,2 +1,6 @@
 /** Unix epoch timestamp in milliseconds. */
 export type TimeStamp = number & { t: 'Epoch time' }
+
+export function timeStampNow(): TimeStamp {
+  return new Date().getTime() as TimeStamp
+}

--- a/packages/core/src/time.ts
+++ b/packages/core/src/time.ts
@@ -1,0 +1,2 @@
+/** Unix epoch timestamp in milliseconds. */
+export type TimeStamp = number & { t: 'Epoch time' }

--- a/packages/core/test/configuration/flagEvaluationEvent.spec.ts
+++ b/packages/core/test/configuration/flagEvaluationEvent.spec.ts
@@ -1,5 +1,5 @@
-import type { TimeStamp } from '@datadog/js-core/time'
 import { createFlagEvaluationEvent } from '../../src/configuration/flagEvaluationEvent'
+import type { TimeStamp } from '../../src/time'
 
 describe('createFlagEvaluationEvent', () => {
   it('should include targeting_key when it is a non-empty string', () => {

--- a/packages/core/test/evaluation/evaluateForSubject.spec.ts
+++ b/packages/core/test/evaluation/evaluateForSubject.spec.ts
@@ -1,6 +1,6 @@
-import type { TimeStamp } from '@datadog/js-core/time'
 import type { EvaluationContext, Logger } from '@openfeature/core'
 import { evaluateForSubject, type Flag } from '../../src/evaluation'
+import type { TimeStamp } from '../../src/time'
 
 describe('evaluateForSubject', () => {
   let logger: Logger

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -36,8 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@datadog/flagging-core": "2.0.1",
-    "@datadog/js-core": "0.0.3"
+    "@datadog/flagging-core": "2.0.1"
   },
   "peerDependencies": {
     "@openfeature/server-sdk": ">=1.15.1"

--- a/packages/node-server/src/provider.ts
+++ b/packages/node-server/src/provider.ts
@@ -5,7 +5,6 @@ import {
   type ExposureEvent,
   LRUInMemoryAssignmentCache,
 } from '@datadog/flagging-core'
-import { timeStampNow } from '@datadog/js-core/time'
 import type { EvaluationContext } from '@openfeature/core'
 import type {
   EvaluationDetails,
@@ -194,7 +193,7 @@ export class DatadogNodeServerProvider implements Provider {
     context: EvaluationContext,
     resolutionDetails: ResolutionDetails<T>
   ): void {
-    const timestamp = timeStampNow()
+    const timestamp = new Date().getTime()
     const evalutationDetails: EvaluationDetails<T> = {
       ...resolutionDetails,
       flagKey: flagKey,

--- a/packages/node-server/src/provider.ts
+++ b/packages/node-server/src/provider.ts
@@ -4,6 +4,7 @@ import {
   createExposureEvent,
   type ExposureEvent,
   LRUInMemoryAssignmentCache,
+  timeStampNow,
 } from '@datadog/flagging-core'
 import type { EvaluationContext } from '@openfeature/core'
 import type {
@@ -193,7 +194,7 @@ export class DatadogNodeServerProvider implements Provider {
     context: EvaluationContext,
     resolutionDetails: ResolutionDetails<T>
   ): void {
-    const timestamp = new Date().getTime()
+    const timestamp = timeStampNow()
     const evalutationDetails: EvaluationDetails<T> = {
       ...resolutionDetails,
       flagKey: flagKey,

--- a/scripts/assert-node-package-purity.js
+++ b/scripts/assert-node-package-purity.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+const forbiddenPackageNames = [/^@datadog\/browser-/, /^@datadog\/js-core$/, /^@datadog\/openfeature-browser$/]
+const browserSdkRepository = /github\.com[/:]DataDog\/browser-sdk(?:\.git)?$/i
+
+const found = new Set()
+const visited = new Set()
+
+function inspectPackage(packageDirectory) {
+  let realDirectory
+  try {
+    realDirectory = fs.realpathSync(packageDirectory)
+  } catch {
+    return
+  }
+
+  if (visited.has(realDirectory)) return
+  visited.add(realDirectory)
+
+  const manifestPath = path.join(realDirectory, 'package.json')
+  if (fs.existsSync(manifestPath)) {
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+    const repository = typeof manifest.repository === 'string' ? manifest.repository : manifest.repository?.url
+    const isBrowserSdkDependency =
+      forbiddenPackageNames.some((pattern) => pattern.test(manifest.name)) ||
+      browserSdkRepository.test(repository ?? '')
+    if (isBrowserSdkDependency) {
+      found.add(manifest.name)
+    }
+  }
+
+  inspectNodeModules(path.join(realDirectory, 'node_modules'))
+}
+
+function inspectNodeModules(nodeModulesDirectory) {
+  if (!fs.existsSync(nodeModulesDirectory)) return
+
+  for (const entry of fs.readdirSync(nodeModulesDirectory, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue
+
+    const entryPath = path.join(nodeModulesDirectory, entry.name)
+    if (entry.name.startsWith('@')) {
+      for (const scopedEntry of fs.readdirSync(entryPath, { withFileTypes: true })) {
+        if (scopedEntry.isDirectory() || scopedEntry.isSymbolicLink()) {
+          inspectPackage(path.join(entryPath, scopedEntry.name))
+        }
+      }
+    } else if (entry.isDirectory() || entry.isSymbolicLink()) {
+      inspectPackage(entryPath)
+    }
+  }
+}
+
+inspectNodeModules(path.resolve(process.argv[2] ?? 'node_modules'))
+
+if (found.size > 0) {
+  console.error('ERROR: Node packages must not install browser SDK dependencies')
+  for (const packageName of [...found].sort()) console.error(packageName)
+  process.exit(1)
+}
+
+console.log('Verified Node packages do not install browser SDK dependencies')

--- a/scripts/test-node-package-install.sh
+++ b/scripts/test-node-package-install.sh
@@ -125,6 +125,8 @@ if [ "$WITH_OPENFEATURE" = true ]; then
   fi
 fi
 
+node "$REPO_ROOT/scripts/assert-node-package-purity.js" node_modules
+
 # Run tests
 echo ""
 echo "Running tests..."

--- a/yarn.lock
+++ b/yarn.lock
@@ -663,7 +663,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/flagging-core@workspace:packages/core"
   dependencies:
-    "@datadog/js-core": "npm:0.0.3"
     "@openfeature/core": "npm:^1.9.2"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^18.0.0"
@@ -741,7 +740,6 @@ __metadata:
   resolution: "@datadog/openfeature-node-server@workspace:packages/node-server"
   dependencies:
     "@datadog/flagging-core": "npm:2.0.1"
-    "@datadog/js-core": "npm:0.0.3"
     "@openfeature/core": "npm:1.9.2"
     "@openfeature/server-sdk": "npm:1.20.2"
     "@types/jest": "npm:^30.0.0"


### PR DESCRIPTION
## Motivation

`@datadog/flagging-core@2.0.1` and `@datadog/openfeature-node-server@2.0.1` both declare `@datadog/js-core@0.0.3`. That package is published from `DataDog/browser-sdk`; its only use in these packages is the timestamp type and helper.

The shared evaluator and Node provider must not install browser SDK runtime dependencies.

## Changes

- Define the branded epoch-millisecond `TimeStamp` type and export `timeStampNow()` from the `@datadog/flagging-core` root API.
- Reuse the core-owned helper for evaluator, aggregation, and Node provider exposure timestamps.
- Remove `@datadog/js-core` from the core and Node package manifests and lockfile edges.
- Extend the existing packed Node installation test with a dependency-tree purity check.
- Fail CI if any installed Node dependency is `@datadog/js-core`, a known browser package, or declares `DataDog/browser-sdk` as its repository.

## Decisions

- Own the timestamp primitive in runtime-agnostic `flagging-core` instead of importing it from the browser SDK.
- Preserve the existing `new Date().getTime()` behavior and branded timestamp values behind the shared helper.
- Keep `@datadog/openfeature-browser` unchanged; it may depend directly on browser SDK packages.
- Enforce purity on the packed, installed dependency tree so transitive browser dependencies are rejected as well as direct ones.
- Preserve the existing timestamp wire values and evaluator-reason behavior.