### PR TITLE
Release js-core dependency removal patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 ---
 
+## @datadog/flagging-core@2.0.2, @datadog/openfeature-browser@1.2.5, @datadog/openfeature-node-server@2.0.2
+
+**Bug Fixes:**
+
+- Remove `@datadog/js-core` from `@datadog/flagging-core` and `@datadog/openfeature-node-server` by moving the epoch timestamp primitive into core ([#342](https://github.com/DataDog/openfeature-js-client/pull/342)) [NODE-SERVER]
+
+**Internal Changes:**
+
+- Enforce packed Node.js dependency-tree purity against browser SDK packages ([#342](https://github.com/DataDog/openfeature-js-client/pull/342)) [NODE-SERVER]
+
 ## @datadog/flagging-core@2.0.1, @datadog/openfeature-browser@1.2.4, @datadog/openfeature-node-server@2.0.1
 
 **Bug Fixes:**

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-browser",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Browser-specific bindings for OpenFeature (wraps @datadog/openfeature-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@datadog/browser-core": "^6.33.0",
-    "@datadog/flagging-core": "2.0.1",
+    "@datadog/flagging-core": "2.0.2",
     "@datadog/js-core": "0.0.3"
   },
   "peerDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/flagging-core",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Runtime-agnostic flag-evaluation logic for Datadog Flagging",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/openfeature-node-server",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Node.js server bindings for OpenFeature (wraps @datadog/flagging-core)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/DataDog/openfeature-js-client#readme",
@@ -36,7 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@datadog/flagging-core": "2.0.1"
+    "@datadog/flagging-core": "2.0.2"
   },
   "peerDependencies": {
     "@openfeature/server-sdk": ">=1.15.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -659,7 +659,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/flagging-core@npm:2.0.1, @datadog/flagging-core@workspace:packages/core":
+"@datadog/flagging-core@npm:2.0.2, @datadog/flagging-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@datadog/flagging-core@workspace:packages/core"
   dependencies:
@@ -688,7 +688,7 @@ __metadata:
   resolution: "@datadog/openfeature-browser@workspace:packages/browser"
   dependencies:
     "@datadog/browser-core": "npm:^6.33.0"
-    "@datadog/flagging-core": "npm:2.0.1"
+    "@datadog/flagging-core": "npm:2.0.2"
     "@datadog/js-core": "npm:0.0.3"
     "@openfeature/core": "npm:^1.9.2"
     "@openfeature/web-sdk": "npm:^1.5.0"
@@ -739,7 +739,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/openfeature-node-server@workspace:packages/node-server"
   dependencies:
-    "@datadog/flagging-core": "npm:2.0.1"
+    "@datadog/flagging-core": "npm:2.0.2"
     "@openfeature/core": "npm:1.9.2"
     "@openfeature/server-sdk": "npm:1.20.2"
     "@types/jest": "npm:^30.0.0"


### PR DESCRIPTION
## Motivation

`@datadog/flagging-core@2.0.1` and `@datadog/openfeature-node-server@2.0.1` install `@datadog/js-core@0.0.3` from `DataDog/browser-sdk` solely for the timestamp primitive. PR #342 moved that primitive into runtime-agnostic core so Node.js consumers no longer pull browser SDK runtime dependencies. These patch releases make that fix available to package consumers.

## Changes

This release advances `@datadog/flagging-core` from `2.0.1` to `2.0.2`, `@datadog/openfeature-browser` from `1.2.4` to `1.2.5`, and `@datadog/openfeature-node-server` from `2.0.1` to `2.0.2`. Browser and Node.js now pin core exactly at `2.0.2`, the lockfile reflects those coordinated versions, and the changelog records the dependency removal and packed Node.js purity check.

## Decisions

The three packages move together because browser and Node.js deliberately pin core to an exact version. Browser retains its direct browser SDK dependencies; the purity boundary applies to core and node-server. The signed package tags were created locally but were not pushed. After this PR is merged with a merge commit, publish in dependency order: core, browser, then node-server.

## Validation

- `bash scripts/internal-deps-validate.sh`
- `bash scripts/versions-validate.sh`
- `yarn licenses:validate`
- `yarn lint`
- `yarn format:check`
- `BUILD_MODE=release yarn build`
- `yarn typecheck`
- `yarn test` (457 tests across 22 suites)
- `yarn test:browser-install`
- `yarn test:node-install` (7/7 consumer checks)
- `yarn test:node-install:with-of` (7/7 consumer checks)
- `yarn lerna run pack --stream`

Validation ran with Node.js v26.5.0.