### PR TITLE
[FFL-2927] Bound browser assignment request latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ---
 
+## Unreleased
+
+**Features:**
+
+- Limit each browser assignment request to one second and retry transient failures once by default. Add timeout and retry-count configuration.
+
 ## @datadog/flagging-core@2.0.2, @datadog/openfeature-browser@1.2.5, @datadog/openfeature-node-server@2.0.2
 
 **Bug Fixes:**

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ const provider = new DatadogProvider({
 
   // Enable flag evaluation tracking
   enableFlagEvaluationTracking: true,
+
+  // Assignment requests use one second per attempt and one retry by default
+  assignmentRequestTimeoutMs: 1000,
+  assignmentRequestRetryCount: 1,
 })
 ```
 

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -49,6 +49,10 @@ const provider = new DatadogProvider({
 
   // Enable flag evaluation tracking
   enableFlagEvaluationTracking: true,
+
+  // Assignment requests use one second per attempt and one retry by default
+  assignmentRequestTimeoutMs: 1000,
+  assignmentRequestRetryCount: 1,
 })
 ```
 

--- a/packages/browser/src/domain/configuration.ts
+++ b/packages/browser/src/domain/configuration.ts
@@ -71,6 +71,16 @@ export interface FlaggingInitConfiguration extends InitConfiguration {
    * Proxy URL for flagging configuration requests. If set, this will be used instead of the site parameter.
    */
   flaggingProxy?: string
+
+  /**
+   * Timeout for each flag assignment request in milliseconds (default: 1000ms).
+   */
+  assignmentRequestTimeoutMs?: number
+
+  /**
+   * Number of retries after a failed flag assignment request (default: 1).
+   */
+  assignmentRequestRetryCount?: number
 }
 
 export interface FlaggingConfiguration extends Configuration {

--- a/packages/browser/src/transport/fetchConfiguration.ts
+++ b/packages/browser/src/transport/fetchConfiguration.ts
@@ -1,4 +1,4 @@
-import type { FlagsConfiguration } from '@datadog/flagging-core'
+import type { FlagsConfiguration, PrecomputedConfigurationResponse } from '@datadog/flagging-core'
 import { timeStampNow } from '@datadog/js-core/time'
 import type { EvaluationContext } from '@openfeature/web-sdk'
 import type { FlaggingInitConfiguration } from '../domain/configuration'
@@ -15,6 +15,20 @@ type JSONAPIError = {
   }[]
 }
 
+const REQUEST_TIMEOUT_MS = 1_000
+const REQUEST_RETRY_COUNT = 1
+
+class HTTPResponseError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message)
+  }
+}
+
+class RequestTimeoutError extends Error {}
+
 async function getErrorMessage(response: Response) {
   if (
     response.headers.get('content-type') === 'application/vnd.api+json' ||
@@ -29,7 +43,77 @@ async function getErrorMessage(response: Response) {
   return response.statusText || 'Unknown error'
 }
 
+function isRetryableStatus(status: number) {
+  return status === 408 || status === 429 || (status >= 500 && status <= 599)
+}
+
+function isRetryableError(error: unknown) {
+  return (
+    error instanceof RequestTimeoutError ||
+    error instanceof TypeError ||
+    (error instanceof HTTPResponseError && isRetryableStatus(error.status))
+  )
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+  callerSignal?: AbortSignal
+): Promise<PrecomputedConfigurationResponse> {
+  const controller = new AbortController()
+  let timedOut = false
+  const abortFromCaller = () => controller.abort(callerSignal?.reason)
+
+  if (callerSignal?.aborted) {
+    abortFromCaller()
+  } else {
+    callerSignal?.addEventListener('abort', abortFromCaller, { once: true })
+  }
+
+  const timeout = setTimeout(() => {
+    timedOut = true
+    controller.abort()
+  }, timeoutMs)
+
+  try {
+    const response = await fetch(url, { ...init, signal: controller.signal })
+    if (!response.ok) {
+      let errorMessage: string
+      try {
+        errorMessage = await getErrorMessage(response)
+      } catch (error) {
+        if (isRetryableStatus(response.status)) {
+          const message = error instanceof Error ? error.message : 'Unknown error'
+          throw new HTTPResponseError(message, response.status)
+        }
+        throw error
+      }
+      throw new HTTPResponseError(`Failed to fetch flag configuration: ${errorMessage}`, response.status)
+    }
+    return (await response.json()) as PrecomputedConfigurationResponse
+  } catch (error) {
+    if (timedOut && !callerSignal?.aborted) {
+      throw new RequestTimeoutError('Flag configuration request timed out')
+    }
+    throw error
+  } finally {
+    clearTimeout(timeout)
+    callerSignal?.removeEventListener('abort', abortFromCaller)
+  }
+}
+
 export function createFlagsConfigurationFetcher(initConfiguration: FlaggingInitConfiguration) {
+  const configuredTimeout = initConfiguration.assignmentRequestTimeoutMs
+  const configuredRetryCount = initConfiguration.assignmentRequestRetryCount
+  const requestTimeoutMs =
+    typeof configuredTimeout === 'number' && Number.isFinite(configuredTimeout) && configuredTimeout > 0
+      ? configuredTimeout
+      : REQUEST_TIMEOUT_MS
+  const requestRetryCount =
+    typeof configuredRetryCount === 'number' && Number.isFinite(configuredRetryCount) && configuredRetryCount >= 0
+      ? Math.floor(configuredRetryCount)
+      : REQUEST_RETRY_COUNT
   let url: URL
   if (initConfiguration.flaggingProxy?.match('https?://')) {
     // If flaggingProxy has a protocol, use it as-is
@@ -66,10 +150,9 @@ export function createFlagsConfigurationFetcher(initConfiguration: FlaggingInitC
       stringifiedContext[key] = typeof value === 'string' ? value : JSON.stringify(value)
     }
 
-    const response = await fetch(url.toString(), {
+    const requestInit: RequestInit = {
       method: 'POST',
       headers: defaultHeaders,
-      signal,
       body: JSON.stringify({
         data: {
           type: 'precompute-assignments-request',
@@ -83,18 +166,25 @@ export function createFlagsConfigurationFetcher(initConfiguration: FlaggingInitC
           },
         },
       }),
-    })
-    if (!response.ok) {
-      const errorMessage = await getErrorMessage(response)
-      throw new Error(`Failed to fetch flag configuration: ${errorMessage}`)
     }
-    const precomputed = await response.json()
-    return {
-      precomputed: {
-        response: precomputed,
-        context,
-        fetchedAt: timeStampNow(),
-      },
+
+    for (let attempt = 0; attempt <= requestRetryCount; attempt += 1) {
+      try {
+        const precomputed = await fetchWithTimeout(url.toString(), requestInit, requestTimeoutMs, signal)
+        return {
+          precomputed: {
+            response: precomputed,
+            context,
+            fetchedAt: timeStampNow(),
+          },
+        }
+      } catch (error) {
+        if (signal?.aborted || attempt === requestRetryCount || !isRetryableError(error)) {
+          throw error
+        }
+      }
     }
+
+    throw new Error('Flag configuration request retry loop completed unexpectedly')
   }
 }

--- a/packages/browser/src/transport/fetchConfiguration.ts
+++ b/packages/browser/src/transport/fetchConfiguration.ts
@@ -15,8 +15,8 @@ type JSONAPIError = {
   }[]
 }
 
-const REQUEST_TIMEOUT_MS = 1_000
-const REQUEST_RETRY_COUNT = 1
+const DEFAULT_REQUEST_TIMEOUT_MS = 1_000
+const DEFAULT_REQUEST_RETRY_COUNT = 1
 
 class HTTPResponseError extends Error {
   constructor(
@@ -44,7 +44,7 @@ async function getErrorMessage(response: Response) {
 }
 
 function isRetryableStatus(status: number) {
-  return status === 408 || status === 429 || (status >= 500 && status <= 599)
+  return status === 408 || (status >= 500 && status <= 599)
 }
 
 function isRetryableError(error: unknown) {
@@ -109,11 +109,11 @@ export function createFlagsConfigurationFetcher(initConfiguration: FlaggingInitC
   const requestTimeoutMs =
     typeof configuredTimeout === 'number' && Number.isFinite(configuredTimeout) && configuredTimeout > 0
       ? configuredTimeout
-      : REQUEST_TIMEOUT_MS
+      : DEFAULT_REQUEST_TIMEOUT_MS
   const requestRetryCount =
     typeof configuredRetryCount === 'number' && Number.isFinite(configuredRetryCount) && configuredRetryCount >= 0
       ? Math.floor(configuredRetryCount)
-      : REQUEST_RETRY_COUNT
+      : DEFAULT_REQUEST_RETRY_COUNT
   let url: URL
   if (initConfiguration.flaggingProxy?.match('https?://')) {
     // If flaggingProxy has a protocol, use it as-is

--- a/packages/browser/test/transport/fetchConfiguration.spec.ts
+++ b/packages/browser/test/transport/fetchConfiguration.spec.ts
@@ -415,6 +415,20 @@ describe('createFlagsConfigurationFetcher', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1)
     })
 
+    it('should not retry a rate-limited response without a retry delay', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+        headers: { get: jest.fn(() => null) },
+      })
+
+      const fetcher = createFlagsConfigurationFetcher(baseConfig)
+
+      await expect(fetcher(mockContext)).rejects.toThrow('Failed to fetch flag configuration: Too Many Requests')
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
     it('should use the configured retry count', async () => {
       mockFetch.mockResolvedValue({
         ok: false,

--- a/packages/browser/test/transport/fetchConfiguration.spec.ts
+++ b/packages/browser/test/transport/fetchConfiguration.spec.ts
@@ -349,4 +349,103 @@ describe('createFlagsConfigurationFetcher', () => {
       })
     })
   })
+
+  describe('request reliability', () => {
+    it('should retry once after a request timeout', async () => {
+      jest.useFakeTimers()
+      mockFetch
+        .mockImplementationOnce((_url: string, init: RequestInit) => {
+          return new Promise((_resolve, reject) => {
+            init.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')))
+          })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: { get: jest.fn(() => 'application/json') },
+          json: jest.fn().mockResolvedValue({ flags: {} }),
+        })
+
+      const fetcher = createFlagsConfigurationFetcher(baseConfig)
+      const resultPromise = fetcher(mockContext)
+
+      await jest.advanceTimersByTimeAsync(1_000)
+
+      await expect(resultPromise).resolves.toEqual({
+        precomputed: {
+          response: { flags: {} },
+          context: mockContext,
+          fetchedAt: 1234567890,
+        },
+      })
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      jest.useRealTimers()
+    })
+
+    it('should retry once after a transient response', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          statusText: 'Server Error',
+          headers: { get: jest.fn(() => null) },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: { get: jest.fn(() => 'application/json') },
+          json: jest.fn().mockResolvedValue({ flags: {} }),
+        })
+
+      const fetcher = createFlagsConfigurationFetcher(baseConfig)
+
+      await expect(fetcher(mockContext)).resolves.toBeDefined()
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should not retry a non-transient response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        headers: { get: jest.fn(() => null) },
+      })
+
+      const fetcher = createFlagsConfigurationFetcher(baseConfig)
+
+      await expect(fetcher(mockContext)).rejects.toThrow('Failed to fetch flag configuration: Bad Request')
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should use the configured retry count', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Server Error',
+        headers: { get: jest.fn(() => null) },
+      })
+      const fetcher = createFlagsConfigurationFetcher({
+        ...baseConfig,
+        assignmentRequestTimeoutMs: 2_000,
+        assignmentRequestRetryCount: 2,
+      })
+
+      await expect(fetcher(mockContext)).rejects.toThrow('Failed to fetch flag configuration: Server Error')
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+    })
+
+    it('should not retry a caller abort', async () => {
+      const controller = new AbortController()
+      mockFetch.mockImplementationOnce((_url: string, init: RequestInit) => {
+        return new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')))
+        })
+      })
+      const fetcher = createFlagsConfigurationFetcher(baseConfig)
+
+      const resultPromise = fetcher(mockContext, { signal: controller.signal })
+      controller.abort()
+
+      await expect(resultPromise).rejects.toMatchObject({ name: 'AbortError' })
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+  })
 })


### PR DESCRIPTION
## Motivation

Precomputed assignment fetches currently rely only on caller cancellation. A slow or unavailable edge can therefore delay provider initialization and evaluation-context changes for several seconds.

The browser SDK needs a bounded default request budget. Applications with different latency requirements must be able to configure that budget.

## Changes and Decisions

- Add `assignmentRequestTimeoutMs` and `assignmentRequestRetryCount` to the public provider configuration.
- Use a 1,000 ms timeout per attempt and one retry by default. The default budget is two attempts of up to one second each.
- Keep the timeout active through response body parsing, not only until response headers arrive.
- Retry timeouts, browser network errors, HTTP 408, and HTTP 5xx responses.
- Do not retry caller cancellation, HTTP 429, or other HTTP 4xx responses.
- Create a new abort controller for each attempt and preserve the caller signal across attempts.
- Define retry count as retries after the first attempt. Set it to zero to disable retries.
- Use the defaults when timeout or retry values are invalid.
- Preserve the existing failure and fallback path after the retry budget ends.

Jira: FFL-2927
