### PR TITLE
feat(browser): include RUM user in evaluation context

### DIFF
--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -108,8 +108,10 @@ DD_RUM.setUser({
 await OpenFeature.setProviderAndWait(new DatadogProvider(configuration))
 ```
 
-If the RUM user changes after provider initialization, call `OpenFeature.setContext()` to reconcile the provider with
-the latest user. Nested RUM user properties are not included in the evaluation context.
+If the RUM user changes after provider initialization, call
+`await OpenFeature.setContext(OpenFeature.getContext())` to reconcile the provider with the latest user while
+preserving explicitly configured OpenFeature properties. Nested RUM user properties are not included in the
+evaluation context.
 
 ## End-user license agreement
 

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -90,6 +90,27 @@ console.log(result.value) // Flag value
 console.log(result.reason) // Evaluation reason
 ```
 
+### RUM User Context
+
+When RUM integration is enabled (the default), the provider includes flat primitive properties returned by
+`DD_RUM.getUser()` in the OpenFeature evaluation context. The RUM user ID is used as the targeting key, while fields
+set explicitly through `OpenFeature.setContext()` take precedence.
+
+Initialize the RUM user before registering the provider:
+
+```javascript
+DD_RUM.setUser({
+  id: 'user-123',
+  email: 'user@example.com',
+  company_name: 'Example, Inc.',
+})
+
+await OpenFeature.setProviderAndWait(new DatadogProvider(configuration))
+```
+
+If the RUM user changes after provider initialization, call `OpenFeature.setContext()` to reconcile the provider with
+the latest user. Nested RUM user properties are not included in the evaluation context.
+
 ## End-user license agreement
 
 https://www.datadoghq.com/legal/eula

--- a/packages/browser/src/domain/configuration.ts
+++ b/packages/browser/src/domain/configuration.ts
@@ -47,7 +47,8 @@ export interface FlaggingInitConfiguration extends InitConfiguration {
   enableFlagEvaluationTracking?: boolean
 
   /**
-   * Whether to include feature flag assignment details in RUM events (default: true)
+   * Whether to enable RUM integration (default: true). This includes feature flag assignment details in RUM events
+   * and flat primitive RUM user properties in the OpenFeature evaluation context.
    * See: https://docs.datadoghq.com/real_user_monitoring/feature_flag_tracking/
    */
   enableRumFeatureFlagTracking?: boolean

--- a/packages/browser/src/openfeature/exposures.ts
+++ b/packages/browser/src/openfeature/exposures.ts
@@ -5,11 +5,16 @@ import { timeStampNow } from '@datadog/js-core/time'
 import type { EvaluationDetails, FlagValue, Hook, HookContext } from '@openfeature/web-sdk'
 import type { FlaggingConfiguration } from '../domain/configuration'
 import { startExposuresBatch } from '../transport/startExposuresBatch'
+import { enrichEvaluationContextWithRumUser } from './rumIntegration'
 
 /**
  * Create hook for exposure logging.
  */
-export function createExposureLoggingHook(configuration: FlaggingConfiguration, exposureCache: AssignmentCache): Hook {
+export function createExposureLoggingHook(
+  configuration: FlaggingConfiguration,
+  exposureCache: AssignmentCache,
+  includeRumUserContext: boolean
+): Hook {
   const pageMayExitObservable = createPageMayExitObservable(configuration)
   const exposuresBatch = startExposuresBatch(
     configuration,
@@ -22,7 +27,10 @@ export function createExposureLoggingHook(configuration: FlaggingConfiguration, 
   return {
     after: (hookContext: HookContext, details: EvaluationDetails<FlagValue>) => {
       const timestamp = timeStampNow()
-      const exposureEvent = createExposureEvent(hookContext.context, details)
+      const evaluationContext = includeRumUserContext
+        ? enrichEvaluationContextWithRumUser(hookContext.context)
+        : hookContext.context
+      const exposureEvent = createExposureEvent(evaluationContext, details)
       if (!exposureEvent) {
         return
       }

--- a/packages/browser/src/openfeature/exposures.ts
+++ b/packages/browser/src/openfeature/exposures.ts
@@ -2,10 +2,9 @@ import type { Context, RawError } from '@datadog/browser-core'
 import { addTelemetryDebug, createPageMayExitObservable } from '@datadog/browser-core'
 import { type AssignmentCache, createExposureEvent, type ExposureEventWithTimestamp } from '@datadog/flagging-core'
 import { timeStampNow } from '@datadog/js-core/time'
-import type { EvaluationDetails, FlagValue, Hook, HookContext } from '@openfeature/web-sdk'
+import type { EvaluationContext, EvaluationDetails, FlagValue, Hook, HookContext } from '@openfeature/web-sdk'
 import type { FlaggingConfiguration } from '../domain/configuration'
 import { startExposuresBatch } from '../transport/startExposuresBatch'
-import { enrichEvaluationContextWithRumUser } from './rumIntegration'
 
 /**
  * Create hook for exposure logging.
@@ -13,7 +12,7 @@ import { enrichEvaluationContextWithRumUser } from './rumIntegration'
 export function createExposureLoggingHook(
   configuration: FlaggingConfiguration,
   exposureCache: AssignmentCache,
-  includeRumUserContext: boolean
+  getEvaluationContext: (context: EvaluationContext) => EvaluationContext = (context) => context
 ): Hook {
   const pageMayExitObservable = createPageMayExitObservable(configuration)
   const exposuresBatch = startExposuresBatch(
@@ -27,9 +26,7 @@ export function createExposureLoggingHook(
   return {
     after: (hookContext: HookContext, details: EvaluationDetails<FlagValue>) => {
       const timestamp = timeStampNow()
-      const evaluationContext = includeRumUserContext
-        ? enrichEvaluationContextWithRumUser(hookContext.context)
-        : hookContext.context
+      const evaluationContext = getEvaluationContext(hookContext.context)
       const exposureEvent = createExposureEvent(evaluationContext, details)
       if (!exposureEvent) {
         return

--- a/packages/browser/src/openfeature/flagEvaluations.ts
+++ b/packages/browser/src/openfeature/flagEvaluations.ts
@@ -9,10 +9,13 @@ import {
   Observable,
 } from '@datadog/browser-core'
 import { FlagEvaluationAggregator, type FlagEvaluationEvent } from '@datadog/flagging-core'
-import type { EvaluationDetails, FlagValue, Hook, HookContext } from '@openfeature/web-sdk'
+import type { EvaluationContext, EvaluationDetails, FlagValue, Hook, HookContext } from '@openfeature/web-sdk'
 import type { FlaggingConfiguration } from '../domain/configuration'
 
-export function createFlagEvalEVPHook(configuration: FlaggingConfiguration): Hook {
+export function createFlagEvalEVPHook(
+  configuration: FlaggingConfiguration,
+  getEvaluationContext: (context: EvaluationContext) => EvaluationContext = (context) => context
+): Hook {
   const pageMayExitObservable = createPageMayExitObservable(configuration)
   const flagEvaluationBatch = createBatch({
     encoder: createIdentityEncoder(),
@@ -63,7 +66,7 @@ export function createFlagEvalEVPHook(configuration: FlaggingConfiguration): Hoo
   return {
     after: (hookContext: HookContext, details: EvaluationDetails<FlagValue>) => {
       try {
-        aggregator.addEvaluation(hookContext.context, details)
+        aggregator.addEvaluation(getEvaluationContext(hookContext.context), details)
       } catch (error) {
         addTelemetryDebug('Error adding evaluation to aggregator', {
           'error.message': error instanceof Error ? error.message : String(error),

--- a/packages/browser/src/openfeature/provider.ts
+++ b/packages/browser/src/openfeature/provider.ts
@@ -67,6 +67,12 @@ export class DatadogProvider implements Provider {
   /** Controls both directions of the provider's RUM integration. */
   private readonly isRumIntegrationEnabled: boolean
 
+  // TODO: Migrate this manual context plumbing to a provider `before` hook once
+  // @openfeature/web-sdk supports returned EvaluationContext values for web hooks.
+  // Watch upstream packages/web/src/hooks/hook.ts for the before return changing from `void`,
+  // and packages/web/src/client/internal/open-feature-client.ts for `beforeHooks` merging that
+  // result before calling the resolver and subsequent hooks. Return this stored context, not a
+  // fresh RUM lookup, so targeting, flag configuration, and telemetry stay on the same identity.
   /** Effective context associated with the active flags configuration. */
   private evaluationContext: EvaluationContext = {}
 

--- a/packages/browser/src/openfeature/provider.ts
+++ b/packages/browser/src/openfeature/provider.ts
@@ -26,7 +26,7 @@ import {
 import { evaluate } from '../evaluation'
 import { createExposureLoggingHook } from './exposures'
 import { createFlagEvalEVPHook } from './flagEvaluations'
-import { createRumTrackingHook } from './rumIntegration'
+import { createRumTrackingHook, enrichEvaluationContextWithRumUser } from './rumIntegration'
 
 /**
  * @deprecated Use FlaggingInitConfiguration instead
@@ -63,6 +63,7 @@ export class DatadogProvider implements Provider {
 
   /** Provider-level configuration */
   private readonly configuration?: FlaggingConfiguration
+  private readonly isRumIntegrationEnabled: boolean
 
   status: ProviderStatus
 
@@ -98,8 +99,8 @@ export class DatadogProvider implements Provider {
     this.hooks = []
     this.events = new OpenFeatureEventEmitter()
 
-    const isRumFeatureFlagTrackingEnabled = options.enableRumFeatureFlagTracking ?? true
-    if (isRumFeatureFlagTrackingEnabled) {
+    this.isRumIntegrationEnabled = options.enableRumFeatureFlagTracking ?? true
+    if (this.isRumIntegrationEnabled) {
       this.hooks.push(createRumTrackingHook())
     }
 
@@ -116,7 +117,7 @@ export class DatadogProvider implements Provider {
         chromeStorage: chromeStorageIfAvailable(),
         storageKeySuffix: 'dd-of-browser',
       })
-      this.hooks.push(createExposureLoggingHook(this.configuration, this.exposureCache))
+      this.hooks.push(createExposureLoggingHook(this.configuration, this.exposureCache, this.isRumIntegrationEnabled))
     }
 
     if (hasIndexedDB()) {
@@ -137,6 +138,8 @@ export class DatadogProvider implements Provider {
   }
 
   private setContext(context: EvaluationContext): Promise<void> {
+    const evaluationContext = this.isRumIntegrationEnabled ? enrichEvaluationContextWithRumUser(context) : context
+
     if (this.status === ProviderStatus.NOT_READY) {
       // we're initializing, no status changes necessary
     } else {
@@ -155,7 +158,7 @@ export class DatadogProvider implements Provider {
     // Important: OF SDK awaits for all onContextChange calls to exit
     // before marking the provider as ready. Make sure to respect
     // `signal`, so we don't block OF SDK unnecessarily.
-    this.latestContextUpdate = this.retrieveFlagsConfiguration(context, { signal })
+    this.latestContextUpdate = this.retrieveFlagsConfiguration(evaluationContext, { signal })
       .then((result) =>
         // New configuration might require clearing exposure
         // cache. One example of this is updating experiment

--- a/packages/browser/src/openfeature/provider.ts
+++ b/packages/browser/src/openfeature/provider.ts
@@ -63,7 +63,12 @@ export class DatadogProvider implements Provider {
 
   /** Provider-level configuration */
   private readonly configuration?: FlaggingConfiguration
+
+  /** Controls both directions of the provider's RUM integration. */
   private readonly isRumIntegrationEnabled: boolean
+
+  /** Effective context associated with the active flags configuration. */
+  private evaluationContext: EvaluationContext = {}
 
   status: ProviderStatus
 
@@ -107,7 +112,7 @@ export class DatadogProvider implements Provider {
     // Add EVP flag evaluation hook.
     const isEvaluationTrackingEnabled = options.enableFlagEvaluationTracking ?? true
     if (isEvaluationTrackingEnabled && this.configuration) {
-      this.hooks.push(createFlagEvalEVPHook(this.configuration))
+      this.hooks.push(createFlagEvalEVPHook(this.configuration, () => this.evaluationContext))
     }
 
     // Add proper exposure logging hook (creates batch internally)
@@ -117,7 +122,7 @@ export class DatadogProvider implements Provider {
         chromeStorage: chromeStorageIfAvailable(),
         storageKeySuffix: 'dd-of-browser',
       })
-      this.hooks.push(createExposureLoggingHook(this.configuration, this.exposureCache, this.isRumIntegrationEnabled))
+      this.hooks.push(createExposureLoggingHook(this.configuration, this.exposureCache, () => this.evaluationContext))
     }
 
     if (hasIndexedDB()) {
@@ -187,6 +192,7 @@ export class DatadogProvider implements Provider {
           // scheduling).
 
           this.flagsConfiguration = config
+          this.evaluationContext = evaluationContext
           this.status = fromCache ? ProviderStatus.STALE : ProviderStatus.READY
           this.events.emit(ProviderEvents.ConfigurationChanged)
 
@@ -271,34 +277,34 @@ export class DatadogProvider implements Provider {
   resolveBooleanEvaluation(
     flagKey: string,
     defaultValue: boolean,
-    context: EvaluationContext,
+    _context: EvaluationContext,
     _logger: Logger
   ): ResolutionDetails<boolean> {
-    return evaluate(this.flagsConfiguration, 'boolean', flagKey, defaultValue, context)
+    return evaluate(this.flagsConfiguration, 'boolean', flagKey, defaultValue, this.evaluationContext)
   }
 
   resolveStringEvaluation(
     flagKey: string,
     defaultValue: string,
-    context: EvaluationContext,
+    _context: EvaluationContext,
     _logger: Logger
   ): ResolutionDetails<string> {
-    return evaluate(this.flagsConfiguration, 'string', flagKey, defaultValue, context)
+    return evaluate(this.flagsConfiguration, 'string', flagKey, defaultValue, this.evaluationContext)
   }
 
   resolveNumberEvaluation(
     flagKey: string,
     defaultValue: number,
-    context: EvaluationContext,
+    _context: EvaluationContext,
     _logger: Logger
   ): ResolutionDetails<number> {
-    return evaluate(this.flagsConfiguration, 'number', flagKey, defaultValue, context)
+    return evaluate(this.flagsConfiguration, 'number', flagKey, defaultValue, this.evaluationContext)
   }
 
   resolveObjectEvaluation<T extends JsonValue>(
     flagKey: string,
     defaultValue: T,
-    context: EvaluationContext,
+    _context: EvaluationContext,
     _logger: Logger
   ): ResolutionDetails<T> {
     // type safety: OpenFeature interface requires us to return a
@@ -307,6 +313,12 @@ export class DatadogProvider implements Provider {
     // type-sound way because there's no runtime information passed to
     // learn what type the user expects. So it's up to the user to
     // make sure they pass the appropriate type.
-    return evaluate(this.flagsConfiguration, 'object', flagKey, defaultValue, context) as ResolutionDetails<T>
+    return evaluate(
+      this.flagsConfiguration,
+      'object',
+      flagKey,
+      defaultValue,
+      this.evaluationContext
+    ) as ResolutionDetails<T>
   }
 }

--- a/packages/browser/src/openfeature/rumIntegration.ts
+++ b/packages/browser/src/openfeature/rumIntegration.ts
@@ -1,13 +1,45 @@
-import { getGlobalObject } from '@datadog/browser-core'
-import type { EvaluationDetails, FlagValue, Hook, HookContext } from '@openfeature/web-sdk'
+import { type Context, getGlobalObject } from '@datadog/browser-core'
+import type { EvaluationContext, EvaluationDetails, FlagValue, Hook, HookContext } from '@openfeature/web-sdk'
 
 export interface DDRum {
   // biome-ignore lint/suspicious/noExplicitAny: DD RUM interface
   addFeatureFlagEvaluation: (flagKey: string, value: any) => void
+  getUser?: () => Context
+}
+
+export function enrichEvaluationContextWithRumUser(context: EvaluationContext): EvaluationContext {
+  try {
+    const globalObject = getGlobalObject<{ DD_RUM?: DDRum }>()
+    const user = globalObject.DD_RUM?.getUser?.()
+    if (!user) {
+      return context
+    }
+
+    const { id, ...attributes } = user
+    const rumUserContext: EvaluationContext = {}
+
+    if (typeof id === 'string') {
+      rumUserContext.targetingKey = id
+    }
+
+    for (const [key, value] of Object.entries(attributes)) {
+      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        rumUserContext[key] = value
+      }
+    }
+
+    return {
+      ...rumUserContext,
+      ...context,
+    }
+  } catch {
+    return context
+  }
 }
 
 export function createRumTrackingHook(): Hook {
   return {
+    before: (hookContext: HookContext) => enrichEvaluationContextWithRumUser(hookContext.context),
     after: (_hookContext: HookContext, details: EvaluationDetails<FlagValue>) => {
       if (details.variant == null) {
         return

--- a/packages/browser/src/openfeature/rumIntegration.ts
+++ b/packages/browser/src/openfeature/rumIntegration.ts
@@ -30,6 +30,7 @@ export function enrichEvaluationContextWithRumUser(context: EvaluationContext): 
 
     return {
       ...rumUserContext,
+      // RUM provides defaults; context explicitly supplied through OpenFeature remains authoritative.
       ...context,
     }
   } catch {
@@ -39,7 +40,6 @@ export function enrichEvaluationContextWithRumUser(context: EvaluationContext): 
 
 export function createRumTrackingHook(): Hook {
   return {
-    before: (hookContext: HookContext) => enrichEvaluationContextWithRumUser(hookContext.context),
     after: (_hookContext: HookContext, details: EvaluationDetails<FlagValue>) => {
       if (details.variant == null) {
         return

--- a/packages/browser/test/openfeature/exposures.spec.ts
+++ b/packages/browser/test/openfeature/exposures.spec.ts
@@ -1,7 +1,8 @@
-import { INTAKE_SITE_STAGING } from '@datadog/browser-core'
+import { getGlobalObject, INTAKE_SITE_STAGING } from '@datadog/browser-core'
 import { OpenFeature } from '@openfeature/web-sdk'
 import type { FlaggingInitConfiguration } from '../../src/domain/configuration'
 import { DatadogProvider } from '../../src/openfeature/provider'
+import type { DDRum } from '../../src/openfeature/rumIntegration'
 import precomputedServerResponse from '../data/precomputed-v1.json'
 
 describe('Exposures End-to-End', () => {
@@ -42,6 +43,8 @@ describe('Exposures End-to-End', () => {
     await OpenFeature.clearContext()
     OpenFeature.clearHandlers()
     OpenFeature.clearHooks()
+    const globalObject = getGlobalObject<{ DD_RUM?: DDRum }>()
+    delete globalObject.DD_RUM
 
     // Clear localStorage to reset assignment cache between tests
     localStorage.clear()
@@ -160,6 +163,90 @@ describe('Exposures End-to-End', () => {
     ]
 
     expect(exposureEvents).toEqual(expectedEvents)
+  })
+
+  it('should include RUM user properties in exposure events', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes('exposures')) {
+        return Promise.resolve({ ok: true, status: 200 })
+      }
+      if (url.includes('precompute-assignments')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(precomputedServerResponse),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+    const globalObject = getGlobalObject<{ DD_RUM?: DDRum }>()
+    globalObject.DD_RUM = {
+      addFeatureFlagEvaluation: jest.fn(),
+      getUser: () => ({
+        id: 'rum-user',
+        user_email: 'rum@example.com',
+        company_name: 'Example, Inc.',
+      }),
+    }
+
+    await OpenFeature.setContext({ user_email: 'explicit@example.com' })
+    await OpenFeature.setProviderAndWait(
+      new DatadogProvider({
+        ...baseProviderConfig,
+        enableExposureLogging: true,
+      })
+    )
+
+    OpenFeature.getClient().getStringValue('string-flag', 'default')
+    triggerBatch()
+
+    const exposureEvents = parseExposureEvents(getExposuresCalls()[0][1].body)
+    expect(exposureEvents[0].subject).toEqual({
+      id: 'rum-user',
+      attributes: {
+        user_email: 'explicit@example.com',
+        company_name: 'Example, Inc.',
+      },
+    })
+  })
+
+  it('should not include RUM user properties when RUM integration is disabled', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes('exposures')) {
+        return Promise.resolve({ ok: true, status: 200 })
+      }
+      if (url.includes('precompute-assignments')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(precomputedServerResponse),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+    const globalObject = getGlobalObject<{ DD_RUM?: DDRum }>()
+    globalObject.DD_RUM = {
+      addFeatureFlagEvaluation: jest.fn(),
+      getUser: () => ({ id: 'rum-user', user_email: 'rum@example.com' }),
+    }
+
+    await OpenFeature.setContext({ targetingKey: 'explicit-user' })
+    await OpenFeature.setProviderAndWait(
+      new DatadogProvider({
+        ...baseProviderConfig,
+        enableExposureLogging: true,
+        enableRumFeatureFlagTracking: false,
+      })
+    )
+
+    OpenFeature.getClient().getStringValue('string-flag', 'default')
+    triggerBatch()
+
+    const exposureEvents = parseExposureEvents(getExposuresCalls()[0][1].body)
+    expect(exposureEvents[0].subject).toEqual({
+      id: 'explicit-user',
+      attributes: {},
+    })
   })
 
   it('should not send exposure events when exposure logging is disabled', async () => {

--- a/packages/browser/test/openfeature/exposures.spec.ts
+++ b/packages/browser/test/openfeature/exposures.spec.ts
@@ -210,6 +210,55 @@ describe('Exposures End-to-End', () => {
     })
   })
 
+  it('should keep exposure identity aligned with the active configuration until context is reconciled', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes('exposures')) {
+        return Promise.resolve({ ok: true, status: 200 })
+      }
+      if (url.includes('precompute-assignments')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(precomputedServerResponse),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+    let rumUser = { id: 'rum-user-a', user_email: 'a@example.com' }
+    const globalObject = getGlobalObject<{ DD_RUM?: DDRum }>()
+    globalObject.DD_RUM = {
+      addFeatureFlagEvaluation: jest.fn(),
+      getUser: () => rumUser,
+    }
+
+    await OpenFeature.setProviderAndWait(
+      new DatadogProvider({
+        ...baseProviderConfig,
+        enableExposureLogging: true,
+      })
+    )
+
+    rumUser = { id: 'rum-user-b', user_email: 'b@example.com' }
+    OpenFeature.getClient().getStringValue('string-flag', 'default')
+    triggerBatch()
+
+    let exposureEvents = parseExposureEvents(getExposuresCalls()[0][1].body)
+    expect(exposureEvents[0].subject).toEqual({
+      id: 'rum-user-a',
+      attributes: { user_email: 'a@example.com' },
+    })
+
+    await OpenFeature.setContext(OpenFeature.getContext())
+    OpenFeature.getClient().getStringValue('string-flag', 'default')
+    triggerBatch()
+
+    exposureEvents = getExposuresCalls().flatMap(([, request]) => parseExposureEvents(request.body))
+    expect(exposureEvents.at(-1)?.subject).toEqual({
+      id: 'rum-user-b',
+      attributes: { user_email: 'b@example.com' },
+    })
+  })
+
   it('should not include RUM user properties when RUM integration is disabled', async () => {
     fetchMock.mockImplementation((url: string) => {
       if (url.includes('exposures')) {

--- a/packages/browser/test/openfeature/flagEvaluations.spec.ts
+++ b/packages/browser/test/openfeature/flagEvaluations.spec.ts
@@ -1,3 +1,4 @@
+import { FlagEvaluationAggregator } from '@datadog/flagging-core'
 import type { EvaluationDetails, HookContext } from '@openfeature/web-sdk'
 import type { FlaggingConfiguration } from '../../src/domain/configuration'
 import { createFlagEvalEVPHook } from '../../src/openfeature/flagEvaluations'
@@ -45,8 +46,6 @@ describe('createFlagEvalEVPHook', () => {
   })
 
   it('should handle evaluation tracking in after hook', () => {
-    const hook = createFlagEvalEVPHook(mockConfiguration)
-
     const mockContext: HookContext = {
       flagKey: 'test-flag',
       defaultValue: true,
@@ -89,8 +88,17 @@ describe('createFlagEvalEVPHook', () => {
       },
     }
 
+    const effectiveContext = {
+      targetingKey: 'rum-user',
+      user_email: 'rum@example.com',
+    }
+    const addEvaluationSpy = jest.spyOn(FlagEvaluationAggregator.prototype, 'addEvaluation')
+    const hook = createFlagEvalEVPHook(mockConfiguration, () => effectiveContext)
+
     expect(() => {
       hook.after?.(mockContext, mockDetails)
     }).not.toThrow()
+    expect(addEvaluationSpy).toHaveBeenCalledWith(effectiveContext, mockDetails)
+    addEvaluationSpy.mockRestore()
   })
 })

--- a/packages/browser/test/openfeature/provider.spec.ts
+++ b/packages/browser/test/openfeature/provider.spec.ts
@@ -1,8 +1,9 @@
-import { INTAKE_SITE_STAGING } from '@datadog/browser-core'
+import { getGlobalObject, INTAKE_SITE_STAGING } from '@datadog/browser-core'
 import { type EvaluationContext, type Logger, StandardResolutionReasons } from '@openfeature/core'
 import { OpenFeature, ProviderEvents, ProviderStatus } from '@openfeature/web-sdk'
 import type { FlaggingInitConfiguration } from '../../src/domain/configuration'
 import { DatadogProvider } from '../../src/openfeature/provider'
+import type { DDRum } from '../../src/openfeature/rumIntegration'
 import precomputedResponse from '../../test/data/precomputed-v1.json'
 
 describe('DatadogProvider', () => {
@@ -301,6 +302,36 @@ describe('DatadogProvider', () => {
           variationType: 'STRING',
         },
       })
+    })
+
+    it('should include RUM user properties in the configuration request', async () => {
+      const globalObject = getGlobalObject<{ DD_RUM?: DDRum }>()
+      globalObject.DD_RUM = {
+        addFeatureFlagEvaluation: jest.fn(),
+        getUser: () => ({
+          id: 'rum-user',
+          user_email: 'rum@example.com',
+          company_name: 'Example, Inc.',
+          profile: { plan: 'enterprise' },
+        }),
+      }
+
+      try {
+        await provider.onContextChange({}, { user_email: 'explicit@example.com' })
+
+        const [, requestOptions] = fetchMock.mock.calls[0]
+        const requestBody = JSON.parse(requestOptions.body)
+        expect(requestBody.data.attributes.subject).toEqual({
+          targeting_key: 'rum-user',
+          targeting_attributes: {
+            targetingKey: 'rum-user',
+            user_email: 'explicit@example.com',
+            company_name: 'Example, Inc.',
+          },
+        })
+      } finally {
+        delete globalObject.DD_RUM
+      }
     })
   })
 

--- a/packages/browser/test/openfeature/rumIntegration.spec.ts
+++ b/packages/browser/test/openfeature/rumIntegration.spec.ts
@@ -116,21 +116,6 @@ describe('createRumTrackingHook', () => {
       })
     })
 
-    it('should enrich context in the before hook', () => {
-      const globalObject = getGlobalObject<{ DD_RUM?: DDRum }>()
-      globalObject.DD_RUM = {
-        addFeatureFlagEvaluation: jest.fn(),
-        getUser: () => ({ id: 'rum-user', company_name: 'Example, Inc.' }),
-      }
-      const hook = createRumTrackingHook()
-
-      expect(hook.before!({ context: { request_attribute: 'request-value' } } as unknown as HookContext)).toEqual({
-        targetingKey: 'rum-user',
-        company_name: 'Example, Inc.',
-        request_attribute: 'request-value',
-      })
-    })
-
     it('should preserve context when RUM user lookup is unavailable', () => {
       const context = { targetingKey: 'explicit-user' }
       expect(enrichEvaluationContextWithRumUser(context)).toBe(context)

--- a/packages/browser/test/openfeature/rumIntegration.spec.ts
+++ b/packages/browser/test/openfeature/rumIntegration.spec.ts
@@ -1,7 +1,7 @@
 import { getGlobalObject } from '@datadog/browser-core'
 import type { EvaluationDetails, FlagValue, HookContext } from '@openfeature/web-sdk'
 import type { DDRum } from '../../src/openfeature/rumIntegration'
-import { createRumTrackingHook } from '../../src/openfeature/rumIntegration'
+import { createRumTrackingHook, enrichEvaluationContextWithRumUser } from '../../src/openfeature/rumIntegration'
 
 describe('createRumTrackingHook', () => {
   const mockHookContext = {} as HookContext
@@ -82,5 +82,67 @@ describe('createRumTrackingHook', () => {
     hook.after!(mockHookContext, details)
 
     expect(mockAddFeatureFlagEvaluation).toHaveBeenCalledWith('my-flag', 'variant-key-a')
+  })
+
+  describe('RUM user context', () => {
+    it('should add flat primitive user properties to the evaluation context', () => {
+      const globalObject = getGlobalObject<{ DD_RUM?: DDRum }>()
+      globalObject.DD_RUM = {
+        addFeatureFlagEvaluation: jest.fn(),
+        getUser: () => ({
+          id: 'rum-user',
+          user_email: 'rum@example.com',
+          company_name: 'Example, Inc.',
+          age: 42,
+          active: true,
+          profile: { plan: 'enterprise' },
+          roles: ['admin'],
+        }),
+      }
+
+      expect(
+        enrichEvaluationContextWithRumUser({
+          targetingKey: 'explicit-user',
+          user_email: 'explicit@example.com',
+          request_attribute: 'request-value',
+        })
+      ).toEqual({
+        targetingKey: 'explicit-user',
+        user_email: 'explicit@example.com',
+        company_name: 'Example, Inc.',
+        age: 42,
+        active: true,
+        request_attribute: 'request-value',
+      })
+    })
+
+    it('should enrich context in the before hook', () => {
+      const globalObject = getGlobalObject<{ DD_RUM?: DDRum }>()
+      globalObject.DD_RUM = {
+        addFeatureFlagEvaluation: jest.fn(),
+        getUser: () => ({ id: 'rum-user', company_name: 'Example, Inc.' }),
+      }
+      const hook = createRumTrackingHook()
+
+      expect(hook.before!({ context: { request_attribute: 'request-value' } } as unknown as HookContext)).toEqual({
+        targetingKey: 'rum-user',
+        company_name: 'Example, Inc.',
+        request_attribute: 'request-value',
+      })
+    })
+
+    it('should preserve context when RUM user lookup is unavailable', () => {
+      const context = { targetingKey: 'explicit-user' }
+      expect(enrichEvaluationContextWithRumUser(context)).toBe(context)
+
+      const globalObject = getGlobalObject<{ DD_RUM?: DDRum }>()
+      globalObject.DD_RUM = {
+        addFeatureFlagEvaluation: jest.fn(),
+        getUser: () => {
+          throw new Error('RUM is not initialized')
+        },
+      }
+      expect(enrichEvaluationContextWithRumUser(context)).toBe(context)
+    })
   })
 })


### PR DESCRIPTION
## Motivation

Customers often set identity attributes such as email and company through the RUM SDK's `setUser()` API, but the browser OpenFeature provider currently requires those same attributes to be configured again through `OpenFeature.setContext()`. As a result, exposure events omit identity data customers already supplied to RUM, which makes it difficult to connect experiment assignments with workflows such as support-ticket analysis.

## Changes

The browser provider now enriches OpenFeature evaluation context from `DD_RUM.getUser()` when RUM integration is enabled. The RUM user ID becomes the OpenFeature targeting key, flat primitive user properties become evaluation attributes, and explicitly supplied OpenFeature fields retain precedence. The same enriched context is used for precomputed-assignment requests and exposure construction so flag assignment and the emitted exposure describe the same subject.

The browser documentation now explains initialization order, precedence, update behavior, and the flat-property constraint. Unit and end-to-end tests cover context merging, precompute request contents, exposure payloads, unavailable RUM state, and the RUM integration opt-out.

## Decisions

The existing `enableRumFeatureFlagTracking` setting remains the integration boundary, so customers who disable RUM integration do not have RUM user data copied into evaluation or exposure context. This avoids introducing a second overlapping RUM toggle.

Only string, number, and boolean RUM properties are copied. Exposure ingestion accepts flat subject attributes, so filtering nested structures in the SDK prevents a nested RUM property from invalidating the entire exposure event. Explicit OpenFeature context wins over RUM-derived values to preserve application intent.

Context enrichment happens during provider reconciliation and through the OpenFeature before hook. Exposure construction also enriches directly because context returned by one hook's before stage is not exposed to a different hook's after callback by the Web SDK.

## Verification

- `yarn workspace @datadog/openfeature-browser test --runInBand` — 156 tests passed
- `yarn workspace @datadog/openfeature-browser typecheck`
- `yarn workspace @datadog/openfeature-browser build`
- `yarn lint`
- `yarn format:check`

## Checklist

- [x] Updated documentation
- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit and end-to-end test coverage
