### PR TITLE
fix(browser): make applicationId optional at runtime

### DIFF
--- a/packages/browser/src/domain/configuration.ts
+++ b/packages/browser/src/domain/configuration.ts
@@ -1,5 +1,5 @@
 import type { Configuration, EndpointBuilder, InitConfiguration } from '@datadog/browser-core'
-import { display, validateAndBuildConfiguration } from '@datadog/browser-core'
+import { validateAndBuildConfiguration } from '@datadog/browser-core'
 import type { FlagsConfiguration } from '@datadog/flagging-core'
 import type { EvaluationContext } from '@openfeature/web-sdk'
 import type { DDRum } from '../openfeature/rumIntegration'
@@ -90,11 +90,6 @@ export interface FlaggingConfiguration extends Configuration {
 export function validateAndBuildFlaggingConfiguration(
   initConfiguration: FlaggingInitConfiguration
 ): FlaggingConfiguration | undefined {
-  if (!initConfiguration.applicationId) {
-    display.error('Application ID is not configured, no flagging data will be collected.')
-    return
-  }
-
   const baseConfiguration = validateAndBuildConfiguration(initConfiguration)
   if (!baseConfiguration) {
     return

--- a/packages/browser/test/openfeature/exposures.spec.ts
+++ b/packages/browser/test/openfeature/exposures.spec.ts
@@ -298,6 +298,39 @@ describe('Exposures End-to-End', () => {
     })
   })
 
+  it('should send exposure events without RUM application attribution when applicationId is not provided', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes('exposures')) {
+        return Promise.resolve({ ok: true, status: 200 })
+      }
+      if (url.includes('precompute-assignments')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(precomputedServerResponse),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+    await OpenFeature.setContext({ targetingKey: 'test-user-123' })
+    const provider = new DatadogProvider({
+      clientToken: 'test-client-token',
+      env: 'test',
+      site: INTAKE_SITE_STAGING,
+      enableExposureLogging: true,
+    })
+    await OpenFeature.setProviderAndWait(provider)
+
+    OpenFeature.getClient().getStringValue('string-flag', 'default')
+    triggerBatch()
+
+    const exposuresCalls = getExposuresCalls()
+    expect(exposuresCalls).toHaveLength(1)
+
+    const [event] = parseExposureEvents(exposuresCalls[0][1].body)
+    expect(event.rum).toEqual({ view: { url: 'http://localhost/' } })
+  })
+
   it('should not send exposure events when exposure logging is disabled', async () => {
     // Mock server response
     fetchMock.mockImplementation((url: string) => {

--- a/packages/browser/test/openfeature/provider.spec.ts
+++ b/packages/browser/test/openfeature/provider.spec.ts
@@ -33,7 +33,6 @@ describe('DatadogProvider', () => {
   describe('configuration validation', () => {
     beforeEach(() => {
       setupProvider()
-      OpenFeature.setProvider(provider)
     })
 
     it('should throw error when ddog-gov.com site is provided', () => {
@@ -139,7 +138,6 @@ describe('DatadogProvider', () => {
   describe('metadata', () => {
     beforeEach(() => {
       setupProvider()
-      OpenFeature.setProvider(provider)
     })
 
     it('should have correct metadata', () => {
@@ -517,6 +515,31 @@ describe('DatadogProvider', () => {
       // Settle both in-flight fetches so the provider doesn't leak
       calls[0].resolve(makeFetchResponse(makeResponse('first')))
       calls[1].resolve(makeFetchResponse(makeResponse('second')))
+    })
+  })
+
+  describe('initialization without applicationId', () => {
+    it('should initialize successfully', async () => {
+      const originalFetch = global.fetch
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => precomputedResponse,
+      })
+      const testProvider = new DatadogProvider({
+        clientToken: 'xxx',
+        env: 'test',
+        site: INTAKE_SITE_STAGING,
+        enableExposureLogging: false,
+        enableFlagEvaluationTracking: false,
+        enableRumFeatureFlagTracking: false,
+      })
+
+      try {
+        await expect(testProvider.initialize()).resolves.toBeUndefined()
+        expect(testProvider.status).toBe(ProviderStatus.READY)
+      } finally {
+        global.fetch = originalFetch
+      }
     })
   })
 


### PR DESCRIPTION
## Summary

- remove the stale runtime guard that rejects browser provider configurations without `applicationId`
- add a regression test proving the provider initializes without an application ID
- add end-to-end coverage proving exposure telemetry is still emitted without RUM application attribution
- remove unnecessary global provider registrations from unit tests so the provider suite remains hermetic

## Why

`FlaggingInitConfiguration.applicationId` and the built configuration both define `applicationId` as optional. Configuration requests already omit `dd-application-id` when it is absent, and exposure and flag-evaluation metadata already include the RUM application ID conditionally.

[FFL-887 / PR #21](https://github.com/DataDog/openfeature-js-client/pull/21) was explicitly intended to support client-token authentication without requiring an application ID, but the previous validation guard was left in place. That guard made the public optional contract unusable at runtime.

The current Datadog JavaScript Feature Flags documentation describes `applicationId` as required for live browser configuration, but the current backend source confirms that it is optional at the transport and intake layers. The documentation should be aligned if this is the intended product contract.

## Backend contract verification

The browser configuration, exposure, flag-evaluation, and RUM paths were traced through the SDK and the receiving services on `dd-source` main:

- [`edge-assignments`](https://github.com/DataDog/dd-source/blob/84e3366b38b818ff147c662af5e59e09bb35f550/domains/ffe/apps/edge-assignments/src/handlers/precompute_assignments.rs#L262-L277) validates only `dd-client-token`; `dd-application-id` is not used for authentication, upstream requests, or cache keys.
- The [exposure](https://github.com/DataDog/dd-source/blob/84e3366b38b818ff147c662af5e59e09bb35f550/domains/evp-workers/apps/exposures-worker/schemas/exposure.json#L43-L68) and [flag-evaluation](https://github.com/DataDog/dd-source/blob/84e3366b38b818ff147c662af5e59e09bb35f550/domains/evp-workers/apps/flageval-worker/schemas/flagevaluation.json#L31-L69) schemas do not require `rum.application.id`; their workers attach RUM application context only when present.
- `applicationId` therefore supplies RUM attribution metadata for exposure and evaluation telemetry. The separate RUM hook uses the already initialized RUM SDK and does not read this provider option.

This confirms the source-level contract. The remaining operational check is that deployed services across supported sites—and any customer-provided proxy—match the reviewed source.

## Downstream behavior when `applicationId` is omitted

- configuration fetches continue with `clientToken` and omit the `dd-application-id` header
- exposure events continue to be sent, but omit `rum.application.id`
- flag-evaluation events continue to be sent, but omit `context.dd.rum.application.id`
- RUM feature-flag tracking is unaffected because it uses the globally initialized RUM SDK
- callers that provide `applicationId` are unchanged
- offline/precomputed initialization can proceed instead of failing local validation

## Validation

- `yarn workspace @datadog/flagging-core build`
- `yarn workspace @datadog/openfeature-browser test --runInBand --no-watchman` — 158 tests passed
- `yarn workspace @datadog/openfeature-browser typecheck`
- `yarn workspace @datadog/openfeature-browser build`
- `yarn lint`
- `yarn format:check`
- `git diff --check`
