### PR TITLE
chore: remove @openfeature/server-sdk as a runtime dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,3 +61,6 @@ jobs:
 
       - name: Test node package installation (with OpenFeature)
         run: yarn test:node-install:with-of
+
+      - name: Test node package installation (with minimum OpenFeature)
+        run: OF_SERVER_SDK_VERSION=1.15.0 OF_CORE_VERSION=1.3.0 yarn test:node-install:with-of

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ esm/
 bundle/
 *.tgz
 *.tar.gz
+packages/node-server/src/.dts-entry.ts
 
 # IDEs
 .idea/

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ test-app/dist
 test-app/node_modules
 test-app/*.tgz
 packages/core/test/ffe-system-test-data
+packages/node-server/index.d.ts

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -360,6 +360,7 @@
 "dot-prop","dot-prop","['MIT']","['Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)']"
 "dotenv","dotenv","['BSD-2-Clause']","['Scott Motte']"
 "dotenv-expand","dotenv-expand","['BSD-2-Clause']","['Scott Motte']"
+"dts-bundle-generator","dts-bundle-generator","['MIT']","['Evgeniy Timokhov']"
 "dunder-proto","dunder-proto","['MIT']","['ECMAScript Shims']"
 "eastasianwidth","eastasianwidth","['MIT']","['Masaki Komagata']"
 "ejs","ejs","['Apache-2.0']","['Joyent, Inc. and other Node contributors']"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,10 @@
   },
   "packageManager": "yarn@4.10.3",
   "resolutions": {
-    "typescript": "5.9.3"
+    "tar@npm:7.5.11": "npm:^7.5.22",
+    "minimatch@npm:10.1.1": "npm:^10.2.6",
+    "js-yaml@npm:4.1.1": "npm:^4.3.1",
+    "typescript@npm:>=5.0.2": "npm:5.9.3"
   },
   "dependencies": {
     "emoji-name-map": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -62,10 +62,5 @@
       "jest>@jest/core>jest-resolve>unrs-resolver": true,
       "lerna>nx": true
     }
-  },
-  "resolutions": {
-    "tar@npm:7.5.11": "npm:^7.5.22",
-    "minimatch@npm:10.1.1": "npm:^10.2.6",
-    "js-yaml@npm:4.1.1": "npm:^4.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "webpack": "5.106.2"
   },
   "packageManager": "yarn@4.10.3",
+  "resolutions": {
+    "typescript": "5.9.3"
+  },
   "dependencies": {
     "emoji-name-map": "^2.0.3"
   },

--- a/packages/node-server/COMPATIBILITY.md
+++ b/packages/node-server/COMPATIBILITY.md
@@ -17,7 +17,7 @@ The provider interface requires features introduced in `@openfeature/server-sdk@
 
 ### Installation
 
-For most users, install the latest versions:
+Install the OpenFeature SDK if your application uses this package as an OpenFeature provider:
 
 ```bash
 npm install @openfeature/server-sdk @openfeature/core
@@ -25,8 +25,8 @@ npm install @openfeature/server-sdk @openfeature/core
 yarn add @openfeature/server-sdk @openfeature/core
 ```
 
-The packages will resolve compatible versions automatically.
+`@datadog/openfeature-node-server` does not install either OpenFeature package as a runtime dependency.
 
 ### For dd-trace Users
 
-If you're using `dd-trace` and don't need OpenFeature functionality directly, you don't need to install these packages. The `@datadog/openfeature-node-server` peer dependency is optional.
+If you're using `dd-trace` and don't need OpenFeature functionality directly, you don't need to install these packages.

--- a/packages/node-server/index.d.ts
+++ b/packages/node-server/index.d.ts
@@ -1,0 +1,641 @@
+import { Channel } from 'node:diagnostics_channel';
+
+export type Metadata = Record<string, string>;
+/**
+ * Defines where the library is intended to be run.
+ */
+export type Paradigm = "server" | "client";
+export type PrimitiveValue = null | boolean | string | number;
+export type JsonObject = {
+	[key: string]: JsonValue;
+};
+export type JsonArray = JsonValue[];
+/**
+ * Represents a JSON node value.
+ */
+export type JsonValue = PrimitiveValue | JsonObject | JsonArray;
+export type EvaluationContextValue = PrimitiveValue | Date | {
+	[key: string]: EvaluationContextValue;
+} | EvaluationContextValue[];
+/**
+ * A container for arbitrary contextual data that can be used as a basis for dynamic evaluation
+ */
+export type EvaluationContext = {
+	/**
+	 * A string uniquely identifying the subject (end-user, or client service) of a flag evaluation.
+	 * Providers may require this field for fractional flag evaluation, rules, or overrides targeting specific users.
+	 * Such providers may behave unpredictably if a targeting key is not specified at flag resolution.
+	 */
+	targetingKey?: string;
+} & Record<string, EvaluationContextValue>;
+export type FlagValueType = "boolean" | "string" | "number" | "object";
+/**
+ * Represents a JSON node value.
+ */
+export type FlagValue = boolean | string | number | JsonValue;
+export type ResolutionReason = keyof typeof StandardResolutionReasons | (string & Record<never, never>);
+/**
+ * A structure which supports definition of arbitrary properties, with keys of type string, and values of type boolean, string, or number.
+ *
+ * This structure is populated by a provider for use by an Application Author (via the Evaluation API) or an Application Integrator (via hooks).
+ */
+export type FlagMetadata = Record<string, string | number | boolean>;
+export type ResolutionDetails<U> = {
+	value: U;
+	variant?: string;
+	flagMetadata?: FlagMetadata;
+	reason?: ResolutionReason;
+	errorCode?: ErrorCode;
+	errorMessage?: string;
+};
+export type EvaluationDetails<T extends FlagValue> = {
+	flagKey: string;
+	flagMetadata: Readonly<FlagMetadata>;
+} & ResolutionDetails<T>;
+declare const StandardResolutionReasons: {
+	/**
+	 * The resolved value is static (no dynamic evaluation).
+	 */
+	readonly STATIC: "STATIC";
+	/**
+	 *  The resolved value was configured statically, or otherwise fell back to a pre-configured value.
+	 */
+	readonly DEFAULT: "DEFAULT";
+	/**
+	 * The resolved value was the result of a dynamic evaluation, such as a rule or specific user-targeting.
+	 */
+	readonly TARGETING_MATCH: "TARGETING_MATCH";
+	/**
+	 * The resolved value was the result of pseudorandom assignment.
+	 */
+	readonly SPLIT: "SPLIT";
+	/**
+	 * The resolved value was retrieved from cache.
+	 */
+	readonly CACHED: "CACHED";
+	/**
+	 * The resolved value was the result of the flag being disabled in the management system.
+	 */
+	readonly DISABLED: "DISABLED";
+	/**
+	 * The reason for the resolved value could not be determined.
+	 */
+	readonly UNKNOWN: "UNKNOWN";
+	/**
+	 * The resolved value is non-authoritative or possibly out of date.
+	 */
+	readonly STALE: "STALE";
+	/**
+	 * The resolved value was the result of an error.
+	 *
+	 * Note: The `errorCode` and `errorMessage` fields may contain additional details of this error.
+	 */
+	readonly ERROR: "ERROR";
+};
+declare enum ErrorCode {
+	/**
+	 * The value was resolved before the provider was ready.
+	 */
+	PROVIDER_NOT_READY = "PROVIDER_NOT_READY",
+	/**
+	 * The provider has entered an irrecoverable error state.
+	 */
+	PROVIDER_FATAL = "PROVIDER_FATAL",
+	/**
+	 * The flag could not be found.
+	 */
+	FLAG_NOT_FOUND = "FLAG_NOT_FOUND",
+	/**
+	 * An error was encountered parsing data, such as a flag configuration.
+	 */
+	PARSE_ERROR = "PARSE_ERROR",
+	/**
+	 * The type of the flag value does not match the expected type.
+	 */
+	TYPE_MISMATCH = "TYPE_MISMATCH",
+	/**
+	 * The provider requires a targeting key and one was not provided in the evaluation context.
+	 */
+	TARGETING_KEY_MISSING = "TARGETING_KEY_MISSING",
+	/**
+	 * The evaluation context does not meet provider requirements.
+	 */
+	INVALID_CONTEXT = "INVALID_CONTEXT",
+	/**
+	 * An error with an unspecified code.
+	 */
+	GENERAL = "GENERAL"
+}
+export interface Logger {
+	error(...args: unknown[]): void;
+	warn(...args: unknown[]): void;
+	info(...args: unknown[]): void;
+	debug(...args: unknown[]): void;
+}
+export interface ManageLogger<T> {
+	/**
+	 * Sets a logger on this receiver. This logger supersedes to the global logger
+	 * and is passed to various components in the SDK.
+	 * The logger configured on the global API object will be used for all evaluations,
+	 * unless overridden in a particular client.
+	 * @template T The type of the receiver
+	 * @param {Logger} logger The logger to be used
+	 * @returns {T} The receiver (this object)
+	 */
+	setLogger(logger: Logger): T;
+}
+declare enum ServerProviderEvents {
+	/**
+	 * The provider is ready to evaluate flags.
+	 */
+	Ready = "PROVIDER_READY",
+	/**
+	 * The provider is in an error state.
+	 */
+	Error = "PROVIDER_ERROR",
+	/**
+	 * The flag configuration in the source-of-truth has changed.
+	 */
+	ConfigurationChanged = "PROVIDER_CONFIGURATION_CHANGED",
+	/**
+	 * The provider's cached state is no longer valid and may not be up-to-date with the source of truth.
+	 */
+	Stale = "PROVIDER_STALE"
+}
+declare enum ClientProviderEvents {
+	/**
+	 * The provider is ready to evaluate flags.
+	 */
+	Ready = "PROVIDER_READY",
+	/**
+	 * The provider is in an error state.
+	 */
+	Error = "PROVIDER_ERROR",
+	/**
+	 * The flag configuration in the source-of-truth has changed.
+	 */
+	ConfigurationChanged = "PROVIDER_CONFIGURATION_CHANGED",
+	/**
+	 * The context associated with the provider has changed, and the provider has reconciled it's associated state.
+	 */
+	ContextChanged = "PROVIDER_CONTEXT_CHANGED",
+	/**
+	 * The context associated with the provider has changed, and the provider has not yet reconciled its associated state.
+	 */
+	Reconciling = "PROVIDER_RECONCILING",
+	/**
+	 * The provider's cached state is no longer valid and may not be up-to-date with the source of truth.
+	 */
+	Stale = "PROVIDER_STALE"
+}
+/**
+ * A type representing any possible ProviderEvent (server or client side).
+ * In most cases, you probably want to import `ProviderEvents` from the respective SDK.
+ */
+export type AnyProviderEvent = ServerProviderEvents | ClientProviderEvents;
+export type EventMetadata = {
+	[key: string]: string | boolean | number;
+};
+export type CommonEventDetails = {
+	readonly providerName: string;
+	/**
+	 * @deprecated alias of "domain", use domain instead
+	 */
+	readonly clientName?: string;
+	readonly domain?: string;
+};
+export type CommonEventProps = {
+	readonly message?: string;
+	readonly metadata?: EventMetadata;
+};
+export type ReadyEvent = CommonEventProps;
+type ErrorEvent$1 = CommonEventProps;
+export type StaleEvent = CommonEventProps;
+export type ConfigChangeEvent = CommonEventProps & {
+	readonly flagsChanged?: string[];
+};
+export type ServerEventMap = {
+	[ServerProviderEvents.Ready]: ReadyEvent;
+	[ServerProviderEvents.Error]: ErrorEvent$1;
+	[ServerProviderEvents.Stale]: StaleEvent;
+	[ServerProviderEvents.ConfigurationChanged]: ConfigChangeEvent;
+};
+export type ClientEventMap = {
+	[ClientProviderEvents.Ready]: ReadyEvent;
+	[ClientProviderEvents.Error]: ErrorEvent$1;
+	[ClientProviderEvents.Stale]: StaleEvent;
+	[ClientProviderEvents.ConfigurationChanged]: ConfigChangeEvent;
+	[ClientProviderEvents.Reconciling]: CommonEventProps;
+	[ClientProviderEvents.ContextChanged]: CommonEventProps;
+};
+export type EventContext<U extends Record<string, unknown> = Record<string, unknown>, T extends ServerProviderEvents | ClientProviderEvents = ServerProviderEvents | ClientProviderEvents> = (T extends ClientProviderEvents ? ClientEventMap[T] : T extends ServerProviderEvents ? ServerEventMap[T] : never) & U;
+export type EventDetails<T extends ServerProviderEvents | ClientProviderEvents = ServerProviderEvents | ClientProviderEvents> = EventContext<Record<string, unknown>, T> & CommonEventDetails;
+export type EventHandler<T extends ServerProviderEvents | ClientProviderEvents = ServerProviderEvents | ClientProviderEvents> = (eventDetails?: EventDetails<T>) => Promise<unknown> | unknown;
+/**
+ * Event emitter to be optionally implemented by providers.
+ * Implemented by @see OpenFeatureEventEmitter.
+ */
+export interface ProviderEventEmitter<E extends AnyProviderEvent, AdditionalContext extends Record<string, unknown> = Record<string, unknown>> extends ManageLogger<ProviderEventEmitter<E, AdditionalContext>> {
+	emit(eventType: E, context?: EventContext): void;
+	addHandler(eventType: AnyProviderEvent, handler: EventHandler): void;
+	removeHandler(eventType: AnyProviderEvent, handler: EventHandler): void;
+	removeAllHandlers(eventType?: AnyProviderEvent): void;
+	getHandlers(eventType: AnyProviderEvent): EventHandler[];
+}
+export type TrackingEventValue = PrimitiveValue | Date | {
+	[key: string]: TrackingEventValue;
+} | TrackingEventValue[];
+/**
+ * A container for arbitrary data that can relevant to tracking events.
+ */
+export type TrackingEventDetails = {
+	/**
+	 * A numeric value associated with this event.
+	 */
+	value?: number;
+} & Record<string, TrackingEventValue>;
+declare enum ServerProviderStatus {
+	/**
+	 * The provider has not been initialized and cannot yet evaluate flags.
+	 */
+	NOT_READY = "NOT_READY",
+	/**
+	 * The provider is ready to resolve flags.
+	 */
+	READY = "READY",
+	/**
+	 * The provider is in an error state and unable to evaluate flags.
+	 */
+	ERROR = "ERROR",
+	/**
+	 * The provider's cached state is no longer valid and may not be up-to-date with the source of truth.
+	 */
+	STALE = "STALE",
+	/**
+	 * The provider has entered an irrecoverable error state.
+	 */
+	FATAL = "FATAL"
+}
+declare enum ClientProviderStatus {
+	/**
+	 * The provider has not been initialized and cannot yet evaluate flags.
+	 */
+	NOT_READY = "NOT_READY",
+	/**
+	 * The provider is ready to resolve flags.
+	 */
+	READY = "READY",
+	/**
+	 * The provider is in an error state and unable to evaluate flags.
+	 */
+	ERROR = "ERROR",
+	/**
+	 * The provider's cached state is no longer valid and may not be up-to-date with the source of truth.
+	 */
+	STALE = "STALE",
+	/**
+	 * The provider has entered an irrecoverable error state.
+	 */
+	FATAL = "FATAL",
+	/**
+	 * The provider is reconciling its state with a context change.
+	 */
+	RECONCILING = "RECONCILING"
+}
+/**
+ * Static data about the provider.
+ */
+export interface ProviderMetadata extends Readonly<Metadata> {
+	readonly name: string;
+}
+export interface CommonProvider<S extends ClientProviderStatus | ServerProviderStatus> {
+	readonly metadata: ProviderMetadata;
+	/**
+	 * Represents where the provider is intended to be run. If defined,
+	 * the SDK will enforce that the defined paradigm at runtime.
+	 */
+	readonly runsOn?: Paradigm;
+	/**
+	 * @deprecated the SDK now maintains the provider's state; there's no need for providers to implement this field.
+	 * Returns a representation of the current readiness of the provider.
+	 *
+	 * _Providers which do not implement this method are assumed to be ready immediately._
+	 */
+	readonly status?: S;
+	/**
+	 * An event emitter for ProviderEvents.
+	 * @see ProviderEvents
+	 */
+	events?: ProviderEventEmitter<AnyProviderEvent>;
+	/**
+	 * A function used to shut down the provider.
+	 * Called when this provider is replaced with a new one, or when the OpenFeature is shut down.
+	 */
+	onClose?(): Promise<void>;
+	/**
+	 * A function used to setup the provider.
+	 * Called by the SDK after the provider is set if the provider's status is NOT_READY.
+	 * When the returned promise resolves, the SDK fires the ProviderEvents.Ready event.
+	 * If the returned promise rejects, the SDK fires the ProviderEvents.Error event.
+	 * Use this function to perform any context-dependent setup within the provider.
+	 * @param context
+	 */
+	initialize?(context?: EvaluationContext): Promise<void>;
+	/**
+	 * Track a user action or application state, usually representing a business objective or outcome.
+	 * @param trackingEventName
+	 * @param context
+	 * @param trackingEventDetails
+	 */
+	track?(trackingEventName: string, context: EvaluationContext, trackingEventDetails: TrackingEventDetails): void;
+}
+export interface ClientMetadata {
+	/**
+	 * @deprecated alias of "domain", use domain instead
+	 */
+	readonly name?: string;
+	readonly domain?: string;
+	readonly version?: string;
+	readonly providerMetadata: ProviderMetadata;
+}
+/**
+ * A mutable data structure for hooks to maintain state across their lifecycle.
+ * Each hook instance gets its own isolated data store that persists for the
+ * duration of a single flag evaluation.
+ * @template TData - A record type that defines the shape of the stored data
+ */
+export interface HookData<TData = Record<string, unknown>> {
+	/**
+	 * Sets a value in the hook data store.
+	 * @param key The key to store the value under
+	 * @param value The value to store
+	 */
+	set<K extends keyof TData>(key: K, value: TData[K]): void;
+	set(key: string, value: unknown): void;
+	/**
+	 * Gets a value from the hook data store.
+	 * @param key The key to retrieve the value for
+	 * @returns The stored value, or undefined if not found
+	 */
+	get<K extends keyof TData>(key: K): TData[K] | undefined;
+	get(key: string): unknown;
+	/**
+	 * Checks if a key exists in the hook data store.
+	 * @param key The key to check
+	 * @returns True if the key exists, false otherwise
+	 */
+	has<K extends keyof TData>(key: K): boolean;
+	has(key: string): boolean;
+	/**
+	 * Deletes a value from the hook data store.
+	 * @param key The key to delete
+	 * @returns True if the key was deleted, false if it didn't exist
+	 */
+	delete<K extends keyof TData>(key: K): boolean;
+	delete(key: string): boolean;
+	/**
+	 * Clears all values from the hook data store.
+	 */
+	clear(): void;
+}
+export type HookHints = Readonly<Record<string, unknown>>;
+export interface HookContext<T extends FlagValue = FlagValue, TData = Record<string, unknown>> {
+	readonly flagKey: string;
+	readonly defaultValue: T;
+	readonly flagValueType: FlagValueType;
+	readonly context: Readonly<EvaluationContext>;
+	readonly clientMetadata: ClientMetadata;
+	readonly providerMetadata: ProviderMetadata;
+	readonly logger: Logger;
+	readonly hookData: HookData<TData>;
+}
+export interface BeforeHookContext<T extends FlagValue = FlagValue, TData = Record<string, unknown>> extends HookContext<T, TData> {
+	context: EvaluationContext;
+}
+export interface BaseHook<T extends FlagValue = FlagValue, TData = Record<string, unknown>, BeforeHookReturn = unknown, HooksReturn = unknown> {
+	/**
+	 * Runs before flag values are resolved from the provider.
+	 * If an EvaluationContext is returned, it will be merged with the pre-existing EvaluationContext.
+	 * @param hookContext
+	 * @param hookHints
+	 */
+	before?(hookContext: BeforeHookContext<T, TData>, hookHints?: HookHints): BeforeHookReturn;
+	/**
+	 * Runs after flag values are successfully resolved from the provider.
+	 * @param hookContext
+	 * @param evaluationDetails
+	 * @param hookHints
+	 */
+	after?(hookContext: Readonly<HookContext<T, TData>>, evaluationDetails: EvaluationDetails<T>, hookHints?: HookHints): HooksReturn;
+	/**
+	 * Runs in the event of an unhandled error or promise rejection during flag resolution, or any attached hooks.
+	 * @param hookContext
+	 * @param error
+	 * @param hookHints
+	 */
+	error?(hookContext: Readonly<HookContext<T, TData>>, error: unknown, hookHints?: HookHints): HooksReturn;
+	/**
+	 * Runs after all other hook stages, regardless of success or error.
+	 * @param hookContext
+	 * @param evaluationDetails
+	 * @param hookHints
+	 */
+	finally?(hookContext: Readonly<HookContext<T, TData>>, evaluationDetails: EvaluationDetails<T>, hookHints?: HookHints): HooksReturn;
+}
+export interface ExposureEvent {
+	allocation: {
+		key: string;
+	};
+	flag: {
+		key: string;
+	};
+	variant: {
+		key: string;
+	};
+	subject: {
+		id: string;
+		attributes: EvaluationContext;
+	};
+	service?: string;
+	rum?: {
+		application?: {
+			id?: string;
+		};
+		view?: {
+			url?: string;
+		};
+	};
+}
+declare enum OperatorType {
+	MATCHES = "MATCHES",
+	NOT_MATCHES = "NOT_MATCHES",
+	GTE = "GTE",
+	GT = "GT",
+	LTE = "LTE",
+	LT = "LT",
+	ONE_OF = "ONE_OF",
+	NOT_ONE_OF = "NOT_ONE_OF",
+	IS_NULL = "IS_NULL"
+}
+export type NumericOperator = OperatorType.GTE | OperatorType.GT | OperatorType.LTE | OperatorType.LT;
+export type MatchesCondition = {
+	operator: OperatorType.MATCHES;
+	attribute: string;
+	value: string;
+};
+export type NotMatchesCondition = {
+	operator: OperatorType.NOT_MATCHES;
+	attribute: string;
+	value: string;
+};
+export type OneOfCondition = {
+	operator: OperatorType.ONE_OF;
+	attribute: string;
+	value: string[];
+};
+export type NotOneOfCondition = {
+	operator: OperatorType.NOT_ONE_OF;
+	attribute: string;
+	value: string[];
+};
+export type NumericCondition = {
+	operator: NumericOperator;
+	attribute: string;
+	value: number;
+};
+export type NullCondition = {
+	operator: OperatorType.IS_NULL;
+	attribute: string;
+	value: boolean;
+};
+export type Condition = MatchesCondition | NotMatchesCondition | OneOfCondition | NotOneOfCondition | NumericCondition | NullCondition;
+export interface Rule {
+	conditions: Condition[];
+}
+export type VariantType = "BOOLEAN" | "INTEGER" | "NUMERIC" | "STRING" | "JSON";
+export interface VariantConfiguration {
+	key: string;
+	value: FlagValue;
+}
+export interface ShardRange {
+	start: number;
+	end: number;
+}
+export interface Shard {
+	salt: string;
+	ranges: ShardRange[];
+	totalShards: number;
+}
+export interface Split {
+	variationKey: string;
+	shards: Shard[];
+	extraLogging?: Record<string, string>;
+	serialId?: number;
+}
+export interface Allocation {
+	key: string;
+	rules?: Rule[];
+	startAt?: Date;
+	endAt?: Date;
+	splits: Split[];
+	doLog?: boolean;
+}
+export interface Flag {
+	key: string;
+	enabled: boolean;
+	variationType: VariantType;
+	variations: Record<string, VariantConfiguration>;
+	allocations: Allocation[];
+}
+export interface UniversalFlagConfigurationV1 {
+	createdAt: string;
+	format: string;
+	environment: {
+		name: string;
+	};
+	flags: Record<string, Flag>;
+}
+export type Hook<TData = Record<string, unknown>> = BaseHook<FlagValue, TData, Promise<EvaluationContext | void> | EvaluationContext | void, Promise<void> | void>;
+/**
+ * Interface that providers must implement to resolve flag values for their particular
+ * backend or vendor.
+ *
+ * Implementation for resolving all the required flag types must be defined.
+ */
+export interface Provider extends CommonProvider<ServerProviderStatus> {
+	/**
+	 * A provider hook exposes a mechanism for provider authors to register hooks
+	 * to tap into various stages of the flag evaluation lifecycle. These hooks can
+	 * be used to perform side effects and mutate the context for purposes of the
+	 * provider. Provider hooks are not configured or controlled by the application author.
+	 */
+	readonly hooks?: Hook[];
+	/**
+	 * Resolve a boolean flag and its evaluation details.
+	 */
+	resolveBooleanEvaluation(flagKey: string, defaultValue: boolean, context: EvaluationContext, logger: Logger): Promise<ResolutionDetails<boolean>>;
+	/**
+	 * Resolve a string flag and its evaluation details.
+	 */
+	resolveStringEvaluation(flagKey: string, defaultValue: string, context: EvaluationContext, logger: Logger): Promise<ResolutionDetails<string>>;
+	/**
+	 * Resolve a numeric flag and its evaluation details.
+	 */
+	resolveNumberEvaluation(flagKey: string, defaultValue: number, context: EvaluationContext, logger: Logger): Promise<ResolutionDetails<number>>;
+	/**
+	 * Resolve and parse an object flag and its evaluation details.
+	 */
+	resolveObjectEvaluation<T extends JsonValue>(flagKey: string, defaultValue: T, context: EvaluationContext, logger: Logger): Promise<ResolutionDetails<T>>;
+}
+export interface DatadogNodeServerProviderOptions {
+	/**
+	 * Log experiment exposures
+	 */
+	exposureChannel: Channel<ExposureEvent>;
+	/**
+	 * Timeout in milliseconds for provider initialization.
+	 * If the configuration is not set within this time, initialization will fail.
+	 * @default DEFAULT_INITIALIZATION_TIMEOUT_MS (30000ms / 30 seconds)
+	 */
+	initializationTimeoutMs?: number;
+}
+export declare class DatadogNodeServerProvider implements Provider {
+	private readonly options;
+	readonly metadata: ProviderMetadata;
+	readonly runsOn: Paradigm;
+	readonly hooks?: Hook[];
+	private initController?;
+	readonly events: ProviderEventEmitter<ServerProviderEvents>;
+	private readonly exposureCache;
+	private configuration?;
+	constructor(options: DatadogNodeServerProviderOptions);
+	/**
+	 * Used by dd-source-js
+	 */
+	getConfiguration(): UniversalFlagConfigurationV1 | undefined;
+	/**
+	 * Used by dd-source-js
+	 */
+	setConfiguration(configuration: UniversalFlagConfigurationV1): void;
+	/**
+	 * Used by dd-source-js
+	 */
+	setError(error: unknown): void;
+	/**
+	 * Used by the OpenFeature SDK to set the status based on initialization.
+	 * Status of 'PROVIDER_READY' is emitted with a resolved promise.
+	 * Status of 'PROVIDER_ERROR' is emitted with a rejected promise.
+	 *
+	 * Since we aren't loading the configuration in this Provider, we will simulate
+	 * loading functionality via InitializationController.
+	 * See setConfiguration and setError for more details.
+	 */
+	initialize(): Promise<void>;
+	resolveBooleanEvaluation(flagKey: string, defaultValue: boolean, context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<boolean>>;
+	resolveStringEvaluation(flagKey: string, defaultValue: string, context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<string>>;
+	resolveNumberEvaluation(flagKey: string, defaultValue: number, context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<number>>;
+	resolveObjectEvaluation<T extends JsonValue>(flagKey: string, defaultValue: T, context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<T>>;
+	private handleExposure;
+}
+
+export {};

--- a/packages/node-server/index.d.ts
+++ b/packages/node-server/index.d.ts
@@ -1,26 +1,17 @@
 import { Channel } from 'node:diagnostics_channel';
 
-export type Metadata = Record<string, string>;
-/**
- * Defines where the library is intended to be run.
- */
-export type Paradigm = "server" | "client";
-export type PrimitiveValue = null | boolean | string | number;
-export type JsonObject = {
+type Metadata = Record<string, string>;
+type Paradigm = "server" | "client";
+type PrimitiveValue = null | boolean | string | number;
+type JsonObject = {
 	[key: string]: JsonValue;
 };
-export type JsonArray = JsonValue[];
-/**
- * Represents a JSON node value.
- */
-export type JsonValue = PrimitiveValue | JsonObject | JsonArray;
-export type EvaluationContextValue = PrimitiveValue | Date | {
+type JsonArray = JsonValue[];
+type JsonValue = PrimitiveValue | JsonObject | JsonArray;
+type EvaluationContextValue = PrimitiveValue | Date | {
 	[key: string]: EvaluationContextValue;
 } | EvaluationContextValue[];
-/**
- * A container for arbitrary contextual data that can be used as a basis for dynamic evaluation
- */
-export type EvaluationContext = {
+type EvaluationContext = {
 	/**
 	 * A string uniquely identifying the subject (end-user, or client service) of a flag evaluation.
 	 * Providers may require this field for fractional flag evaluation, rules, or overrides targeting specific users.
@@ -28,19 +19,11 @@ export type EvaluationContext = {
 	 */
 	targetingKey?: string;
 } & Record<string, EvaluationContextValue>;
-export type FlagValueType = "boolean" | "string" | "number" | "object";
-/**
- * Represents a JSON node value.
- */
-export type FlagValue = boolean | string | number | JsonValue;
-export type ResolutionReason = keyof typeof StandardResolutionReasons | (string & Record<never, never>);
-/**
- * A structure which supports definition of arbitrary properties, with keys of type string, and values of type boolean, string, or number.
- *
- * This structure is populated by a provider for use by an Application Author (via the Evaluation API) or an Application Integrator (via hooks).
- */
-export type FlagMetadata = Record<string, string | number | boolean>;
-export type ResolutionDetails<U> = {
+type FlagValueType = "boolean" | "string" | "number" | "object";
+type FlagValue = boolean | string | number | JsonValue;
+type ResolutionReason = keyof typeof StandardResolutionReasons | (string & Record<never, never>);
+type FlagMetadata = Record<string, string | number | boolean>;
+type ResolutionDetails<U> = {
 	value: U;
 	variant?: string;
 	flagMetadata?: FlagMetadata;
@@ -48,7 +31,7 @@ export type ResolutionDetails<U> = {
 	errorCode?: ErrorCode;
 	errorMessage?: string;
 };
-export type EvaluationDetails<T extends FlagValue> = {
+type EvaluationDetails<T extends FlagValue> = {
 	flagKey: string;
 	flagMetadata: Readonly<FlagMetadata>;
 } & ResolutionDetails<T>;
@@ -126,13 +109,13 @@ declare enum ErrorCode {
 	 */
 	GENERAL = "GENERAL"
 }
-export interface Logger {
+interface Logger {
 	error(...args: unknown[]): void;
 	warn(...args: unknown[]): void;
 	info(...args: unknown[]): void;
 	debug(...args: unknown[]): void;
 }
-export interface ManageLogger<T> {
+interface ManageLogger<T> {
 	/**
 	 * Sets a logger on this receiver. This logger supersedes to the global logger
 	 * and is passed to various components in the SDK.
@@ -188,15 +171,11 @@ declare enum ClientProviderEvents {
 	 */
 	Stale = "PROVIDER_STALE"
 }
-/**
- * A type representing any possible ProviderEvent (server or client side).
- * In most cases, you probably want to import `ProviderEvents` from the respective SDK.
- */
-export type AnyProviderEvent = ServerProviderEvents | ClientProviderEvents;
-export type EventMetadata = {
+type AnyProviderEvent = ServerProviderEvents | ClientProviderEvents;
+type EventMetadata = {
 	[key: string]: string | boolean | number;
 };
-export type CommonEventDetails = {
+type CommonEventDetails = {
 	readonly providerName: string;
 	/**
 	 * @deprecated alias of "domain", use domain instead
@@ -204,23 +183,23 @@ export type CommonEventDetails = {
 	readonly clientName?: string;
 	readonly domain?: string;
 };
-export type CommonEventProps = {
+type CommonEventProps = {
 	readonly message?: string;
 	readonly metadata?: EventMetadata;
 };
-export type ReadyEvent = CommonEventProps;
+type ReadyEvent = CommonEventProps;
 type ErrorEvent$1 = CommonEventProps;
-export type StaleEvent = CommonEventProps;
-export type ConfigChangeEvent = CommonEventProps & {
+type StaleEvent = CommonEventProps;
+type ConfigChangeEvent = CommonEventProps & {
 	readonly flagsChanged?: string[];
 };
-export type ServerEventMap = {
+type ServerEventMap = {
 	[ServerProviderEvents.Ready]: ReadyEvent;
 	[ServerProviderEvents.Error]: ErrorEvent$1;
 	[ServerProviderEvents.Stale]: StaleEvent;
 	[ServerProviderEvents.ConfigurationChanged]: ConfigChangeEvent;
 };
-export type ClientEventMap = {
+type ClientEventMap = {
 	[ClientProviderEvents.Ready]: ReadyEvent;
 	[ClientProviderEvents.Error]: ErrorEvent$1;
 	[ClientProviderEvents.Stale]: StaleEvent;
@@ -228,27 +207,20 @@ export type ClientEventMap = {
 	[ClientProviderEvents.Reconciling]: CommonEventProps;
 	[ClientProviderEvents.ContextChanged]: CommonEventProps;
 };
-export type EventContext<U extends Record<string, unknown> = Record<string, unknown>, T extends ServerProviderEvents | ClientProviderEvents = ServerProviderEvents | ClientProviderEvents> = (T extends ClientProviderEvents ? ClientEventMap[T] : T extends ServerProviderEvents ? ServerEventMap[T] : never) & U;
-export type EventDetails<T extends ServerProviderEvents | ClientProviderEvents = ServerProviderEvents | ClientProviderEvents> = EventContext<Record<string, unknown>, T> & CommonEventDetails;
-export type EventHandler<T extends ServerProviderEvents | ClientProviderEvents = ServerProviderEvents | ClientProviderEvents> = (eventDetails?: EventDetails<T>) => Promise<unknown> | unknown;
-/**
- * Event emitter to be optionally implemented by providers.
- * Implemented by @see OpenFeatureEventEmitter.
- */
-export interface ProviderEventEmitter<E extends AnyProviderEvent, AdditionalContext extends Record<string, unknown> = Record<string, unknown>> extends ManageLogger<ProviderEventEmitter<E, AdditionalContext>> {
+type EventContext<U extends Record<string, unknown> = Record<string, unknown>, T extends ServerProviderEvents | ClientProviderEvents = ServerProviderEvents | ClientProviderEvents> = (T extends ClientProviderEvents ? ClientEventMap[T] : T extends ServerProviderEvents ? ServerEventMap[T] : never) & U;
+type EventDetails<T extends ServerProviderEvents | ClientProviderEvents = ServerProviderEvents | ClientProviderEvents> = EventContext<Record<string, unknown>, T> & CommonEventDetails;
+type EventHandler<T extends ServerProviderEvents | ClientProviderEvents = ServerProviderEvents | ClientProviderEvents> = (eventDetails?: EventDetails<T>) => Promise<unknown> | unknown;
+interface ProviderEventEmitter<E extends AnyProviderEvent, AdditionalContext extends Record<string, unknown> = Record<string, unknown>> extends ManageLogger<ProviderEventEmitter<E, AdditionalContext>> {
 	emit(eventType: E, context?: EventContext): void;
 	addHandler(eventType: AnyProviderEvent, handler: EventHandler): void;
 	removeHandler(eventType: AnyProviderEvent, handler: EventHandler): void;
 	removeAllHandlers(eventType?: AnyProviderEvent): void;
 	getHandlers(eventType: AnyProviderEvent): EventHandler[];
 }
-export type TrackingEventValue = PrimitiveValue | Date | {
+type TrackingEventValue = PrimitiveValue | Date | {
 	[key: string]: TrackingEventValue;
 } | TrackingEventValue[];
-/**
- * A container for arbitrary data that can relevant to tracking events.
- */
-export type TrackingEventDetails = {
+type TrackingEventDetails = {
 	/**
 	 * A numeric value associated with this event.
 	 */
@@ -302,13 +274,10 @@ declare enum ClientProviderStatus {
 	 */
 	RECONCILING = "RECONCILING"
 }
-/**
- * Static data about the provider.
- */
-export interface ProviderMetadata extends Readonly<Metadata> {
+interface ProviderMetadata extends Readonly<Metadata> {
 	readonly name: string;
 }
-export interface CommonProvider<S extends ClientProviderStatus | ServerProviderStatus> {
+interface CommonProvider<S extends ClientProviderStatus | ServerProviderStatus> {
 	readonly metadata: ProviderMetadata;
 	/**
 	 * Represents where the provider is intended to be run. If defined,
@@ -349,7 +318,7 @@ export interface CommonProvider<S extends ClientProviderStatus | ServerProviderS
 	 */
 	track?(trackingEventName: string, context: EvaluationContext, trackingEventDetails: TrackingEventDetails): void;
 }
-export interface ClientMetadata {
+interface ClientMetadata {
 	/**
 	 * @deprecated alias of "domain", use domain instead
 	 */
@@ -358,13 +327,7 @@ export interface ClientMetadata {
 	readonly version?: string;
 	readonly providerMetadata: ProviderMetadata;
 }
-/**
- * A mutable data structure for hooks to maintain state across their lifecycle.
- * Each hook instance gets its own isolated data store that persists for the
- * duration of a single flag evaluation.
- * @template TData - A record type that defines the shape of the stored data
- */
-export interface HookData<TData = Record<string, unknown>> {
+interface HookData<TData = Record<string, unknown>> {
 	/**
 	 * Sets a value in the hook data store.
 	 * @param key The key to store the value under
@@ -398,8 +361,8 @@ export interface HookData<TData = Record<string, unknown>> {
 	 */
 	clear(): void;
 }
-export type HookHints = Readonly<Record<string, unknown>>;
-export interface HookContext<T extends FlagValue = FlagValue, TData = Record<string, unknown>> {
+type HookHints = Readonly<Record<string, unknown>>;
+interface HookContext<T extends FlagValue = FlagValue, TData = Record<string, unknown>> {
 	readonly flagKey: string;
 	readonly defaultValue: T;
 	readonly flagValueType: FlagValueType;
@@ -409,10 +372,10 @@ export interface HookContext<T extends FlagValue = FlagValue, TData = Record<str
 	readonly logger: Logger;
 	readonly hookData: HookData<TData>;
 }
-export interface BeforeHookContext<T extends FlagValue = FlagValue, TData = Record<string, unknown>> extends HookContext<T, TData> {
+interface BeforeHookContext<T extends FlagValue = FlagValue, TData = Record<string, unknown>> extends HookContext<T, TData> {
 	context: EvaluationContext;
 }
-export interface BaseHook<T extends FlagValue = FlagValue, TData = Record<string, unknown>, BeforeHookReturn = unknown, HooksReturn = unknown> {
+interface BaseHook<T extends FlagValue = FlagValue, TData = Record<string, unknown>, BeforeHookReturn = unknown, HooksReturn = unknown> {
 	/**
 	 * Runs before flag values are resolved from the provider.
 	 * If an EvaluationContext is returned, it will be merged with the pre-existing EvaluationContext.
@@ -442,7 +405,7 @@ export interface BaseHook<T extends FlagValue = FlagValue, TData = Record<string
 	 */
 	finally?(hookContext: Readonly<HookContext<T, TData>>, evaluationDetails: EvaluationDetails<T>, hookHints?: HookHints): HooksReturn;
 }
-export interface ExposureEvent {
+interface ExposureEvent {
 	allocation: {
 		key: string;
 	};
@@ -477,62 +440,62 @@ declare enum OperatorType {
 	NOT_ONE_OF = "NOT_ONE_OF",
 	IS_NULL = "IS_NULL"
 }
-export type NumericOperator = OperatorType.GTE | OperatorType.GT | OperatorType.LTE | OperatorType.LT;
-export type MatchesCondition = {
+type NumericOperator = OperatorType.GTE | OperatorType.GT | OperatorType.LTE | OperatorType.LT;
+type MatchesCondition = {
 	operator: OperatorType.MATCHES;
 	attribute: string;
 	value: string;
 };
-export type NotMatchesCondition = {
+type NotMatchesCondition = {
 	operator: OperatorType.NOT_MATCHES;
 	attribute: string;
 	value: string;
 };
-export type OneOfCondition = {
+type OneOfCondition = {
 	operator: OperatorType.ONE_OF;
 	attribute: string;
 	value: string[];
 };
-export type NotOneOfCondition = {
+type NotOneOfCondition = {
 	operator: OperatorType.NOT_ONE_OF;
 	attribute: string;
 	value: string[];
 };
-export type NumericCondition = {
+type NumericCondition = {
 	operator: NumericOperator;
 	attribute: string;
 	value: number;
 };
-export type NullCondition = {
+type NullCondition = {
 	operator: OperatorType.IS_NULL;
 	attribute: string;
 	value: boolean;
 };
-export type Condition = MatchesCondition | NotMatchesCondition | OneOfCondition | NotOneOfCondition | NumericCondition | NullCondition;
-export interface Rule {
+type Condition = MatchesCondition | NotMatchesCondition | OneOfCondition | NotOneOfCondition | NumericCondition | NullCondition;
+interface Rule {
 	conditions: Condition[];
 }
-export type VariantType = "BOOLEAN" | "INTEGER" | "NUMERIC" | "STRING" | "JSON";
-export interface VariantConfiguration {
+type VariantType = "BOOLEAN" | "INTEGER" | "NUMERIC" | "STRING" | "JSON";
+interface VariantConfiguration {
 	key: string;
 	value: FlagValue;
 }
-export interface ShardRange {
+interface ShardRange {
 	start: number;
 	end: number;
 }
-export interface Shard {
+interface Shard {
 	salt: string;
 	ranges: ShardRange[];
 	totalShards: number;
 }
-export interface Split {
+interface Split {
 	variationKey: string;
 	shards: Shard[];
 	extraLogging?: Record<string, string>;
 	serialId?: number;
 }
-export interface Allocation {
+interface Allocation {
 	key: string;
 	rules?: Rule[];
 	startAt?: Date;
@@ -540,7 +503,7 @@ export interface Allocation {
 	splits: Split[];
 	doLog?: boolean;
 }
-export interface Flag {
+interface Flag {
 	key: string;
 	enabled: boolean;
 	variationType: VariantType;
@@ -555,14 +518,8 @@ export interface UniversalFlagConfigurationV1 {
 	};
 	flags: Record<string, Flag>;
 }
-export type Hook<TData = Record<string, unknown>> = BaseHook<FlagValue, TData, Promise<EvaluationContext | void> | EvaluationContext | void, Promise<void> | void>;
-/**
- * Interface that providers must implement to resolve flag values for their particular
- * backend or vendor.
- *
- * Implementation for resolving all the required flag types must be defined.
- */
-export interface Provider extends CommonProvider<ServerProviderStatus> {
+type Hook<TData = Record<string, unknown>> = BaseHook<FlagValue, TData, Promise<EvaluationContext | void> | EvaluationContext | void, Promise<void> | void>;
+interface Provider extends CommonProvider<ServerProviderStatus> {
 	/**
 	 * A provider hook exposes a mechanism for provider authors to register hooks
 	 * to tap into various stages of the flag evaluation lifecycle. These hooks can

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -38,9 +38,6 @@
   "dependencies": {
     "@datadog/flagging-core": "2.0.2"
   },
-  "peerDependencies": {
-    "@openfeature/server-sdk": ">=1.15.1"
-  },
   "devDependencies": {
     "@openfeature/core": "1.9.2",
     "@openfeature/server-sdk": "1.20.2",

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -44,11 +44,11 @@
     "@openfeature/server-sdk": "1.20.2",
     "@types/jest": "^30.0.0",
     "@types/node": "^18.19.130",
+    "dts-bundle-generator": "^9.0.0",
     "jest": "^30.0.5",
     "npm-run-all": "^4.1.5",
     "ts-jest": "^29.4.9",
     "ts-loader": "^9.5.7",
-    "typescript": "^5.9.3",
-    "dts-bundle-generator": "^9.0.0"
+    "typescript": "^5.9.3"
   }
 }

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -14,7 +14,7 @@
   },
   "main": "cjs/index.js",
   "module": "esm/index.js",
-  "types": "cjs/index.d.ts",
+  "types": "index.d.ts",
   "sideEffects": false,
   "files": [
     "cjs/",
@@ -27,9 +27,10 @@
   "scripts": {
     "prepack": "yarn build",
     "pack": "yarn pack",
-    "build": "run-p build:cjs build:esm",
+    "build": "run-p build:cjs build:esm && yarn build:types",
     "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json && yarn replace-build-env cjs",
     "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json && yarn replace-build-env esm",
+    "build:types": "printf '/// <reference path=\"./global.d.ts\" />\\nexport * from \"./index\"\\n' > src/.dts-entry.ts && dts-bundle-generator -o index.d.ts src/.dts-entry.ts --external-inlines @openfeature/core @openfeature/server-sdk --no-banner && rm -f src/.dts-entry.ts",
     "replace-build-env": "node ../../scripts/build/replace-build-env.js",
     "clean": "rm -rf dist cjs esm",
     "test": "jest --passWithNoTests",
@@ -47,6 +48,7 @@
     "npm-run-all": "^4.1.5",
     "ts-jest": "^29.4.9",
     "ts-loader": "^9.5.7",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "dts-bundle-generator": "^9.0.0"
   }
 }

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -25,7 +25,7 @@
     "access": "public"
   },
   "scripts": {
-    "prepack": "yarn build",
+    "prepack": "yarn build && node scripts/verify-no-openfeature-dep.js",
     "pack": "yarn pack",
     "build": "run-p build:cjs build:esm && yarn build:types",
     "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json && yarn replace-build-env cjs",

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -30,7 +30,7 @@
     "build": "run-p build:cjs build:esm && yarn build:types",
     "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json && yarn replace-build-env cjs",
     "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json && yarn replace-build-env esm",
-    "build:types": "printf '/// <reference path=\"./global.d.ts\" />\\nexport * from \"./index\"\\n' > src/.dts-entry.ts && dts-bundle-generator -o index.d.ts src/.dts-entry.ts --external-inlines @openfeature/core @openfeature/server-sdk --no-banner && rm -f src/.dts-entry.ts",
+    "build:types": "printf '/// <reference path=\"./global.d.ts\" />\\nexport * from \"./index\"\\n' > src/.dts-entry.ts && dts-bundle-generator -o index.d.ts src/.dts-entry.ts --external-inlines @openfeature/core @openfeature/server-sdk --no-banner --export-referenced-types false && rm -f src/.dts-entry.ts",
     "replace-build-env": "node ../../scripts/build/replace-build-env.js",
     "clean": "rm -rf dist cjs esm",
     "test": "jest --passWithNoTests",

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -30,6 +30,7 @@
     "build": "run-p build:cjs build:esm && yarn build:types",
     "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json && yarn replace-build-env cjs",
     "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json && yarn replace-build-env esm",
+    "//build:types": "Bundles @openfeature/* types into a self-contained index.d.ts with no external imports, required for SSI where dd-trace's node_modules can't reach the customer's @openfeature/server-sdk. See https://github.com/DataDog/dd-trace-js/pull/9570",
     "build:types": "trap 'rm -f src/.dts-entry.ts' EXIT; printf '/// <reference path=\"./global.d.ts\" />\\nexport * from \"./index\"\\n' > src/.dts-entry.ts && dts-bundle-generator -o index.d.ts src/.dts-entry.ts --external-inlines @openfeature/core @openfeature/server-sdk --no-banner --export-referenced-types false",
     "replace-build-env": "node ../../scripts/build/replace-build-env.js",
     "clean": "rm -rf dist cjs esm index.d.ts",

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -30,9 +30,9 @@
     "build": "run-p build:cjs build:esm && yarn build:types",
     "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json && yarn replace-build-env cjs",
     "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json && yarn replace-build-env esm",
-    "build:types": "printf '/// <reference path=\"./global.d.ts\" />\\nexport * from \"./index\"\\n' > src/.dts-entry.ts && dts-bundle-generator -o index.d.ts src/.dts-entry.ts --external-inlines @openfeature/core @openfeature/server-sdk --no-banner --export-referenced-types false && rm -f src/.dts-entry.ts",
+    "build:types": "trap 'rm -f src/.dts-entry.ts' EXIT; printf '/// <reference path=\"./global.d.ts\" />\\nexport * from \"./index\"\\n' > src/.dts-entry.ts && dts-bundle-generator -o index.d.ts src/.dts-entry.ts --external-inlines @openfeature/core @openfeature/server-sdk --no-banner --export-referenced-types false",
     "replace-build-env": "node ../../scripts/build/replace-build-env.js",
-    "clean": "rm -rf dist cjs esm",
+    "clean": "rm -rf dist cjs esm index.d.ts",
     "test": "jest --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/node-server/scripts/verify-no-openfeature-dep.js
+++ b/packages/node-server/scripts/verify-no-openfeature-dep.js
@@ -36,10 +36,10 @@ for (const section of ['dependencies', 'peerDependencies']) {
     if (dep in pkg[section]) {
       fail(
         `"${dep}" is listed in "${section}" in package.json.\n` +
-        `  This would install a separate copy under SSI, breaking event emitter\n` +
-        `  identity with the customer's @openfeature/server-sdk.\n` +
-        `  See https://github.com/DataDog/dd-trace-js/pull/9570 for context.\n` +
-        `  If you need OpenFeature types, keep them in "devDependencies" only.`
+          `  This would install a separate copy under SSI, breaking event emitter\n` +
+          `  identity with the customer's @openfeature/server-sdk.\n` +
+          `  See https://github.com/DataDog/dd-trace-js/pull/9570 for context.\n` +
+          `  If you need OpenFeature types, keep them in "devDependencies" only.`
       )
     }
   }
@@ -52,12 +52,12 @@ function checkDir(dir, label) {
     if (!file.endsWith('.js')) continue
     const content = fs.readFileSync(path.join(dir, file), 'utf8')
     // Match require('@openfeature/...') or from '@openfeature/...'
-    if (content.includes("@openfeature/")) {
+    if (content.includes('@openfeature/')) {
       fail(
         `Runtime @openfeature import found in ${label}/${file}.\n` +
-        `  The compiled output must not import from @openfeature/* at runtime.\n` +
-        `  All OpenFeature types must be import type only (erased at compile time)\n` +
-        `  and the event emitter must use the custom NodeProviderEventEmitter.`
+          `  The compiled output must not import from @openfeature/* at runtime.\n` +
+          `  All OpenFeature types must be import type only (erased at compile time)\n` +
+          `  and the event emitter must use the custom NodeProviderEventEmitter.`
       )
     }
   }
@@ -69,9 +69,9 @@ checkDir(ESM_DIR, 'esm')
 if (failed) {
   console.error(
     '\n\x1b[31m[verify-no-openfeature-dep] ' +
-    'Publishing blocked. @openfeature/server-sdk must remain a devDependency ' +
-    'only. Adding it as a runtime dependency breaks SSI compatibility with ' +
-    'dd-trace-js (see https://github.com/DataDog/dd-trace-js/pull/9570).\x1b[0m\n'
+      'Publishing blocked. @openfeature/server-sdk must remain a devDependency ' +
+      'only. Adding it as a runtime dependency breaks SSI compatibility with ' +
+      'dd-trace-js (see https://github.com/DataDog/dd-trace-js/pull/9570).\x1b[0m\n'
   )
   process.exit(1)
 } else {

--- a/packages/node-server/scripts/verify-no-openfeature-dep.js
+++ b/packages/node-server/scripts/verify-no-openfeature-dep.js
@@ -1,0 +1,79 @@
+'use strict'
+
+/**
+ * Pre-publish guard: ensures @openfeature/server-sdk and @openfeature/core
+ * are NOT declared as runtime dependencies and are NOT imported at runtime.
+ *
+ * Adding either as a dependency would give dd-trace-js its own copy of the
+ * SDK under SSI (Single Step Instrumentation), where dd-trace is installed
+ * outside the application's node_modules tree. That copy would have a
+ * different identity than the customer's, breaking event emitter sharing.
+ *
+ * See https://github.com/DataDog/dd-trace-js/pull/9570 for context.
+ */
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+const FORBIDDEN_PACKAGES = ['@openfeature/server-sdk', '@openfeature/core']
+const PACKAGE_JSON = path.join(__dirname, '..', 'package.json')
+const CJS_DIR = path.join(__dirname, '..', 'cjs')
+const ESM_DIR = path.join(__dirname, '..', 'esm')
+
+let failed = false
+
+function fail(message) {
+  console.error(`\x1b[31m[verify-no-openfeature-dep] ERROR: ${message}\x1b[0m`)
+  failed = true
+}
+
+// --- Check package.json ---
+const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf8'))
+
+for (const section of ['dependencies', 'peerDependencies']) {
+  if (!pkg[section]) continue
+  for (const dep of FORBIDDEN_PACKAGES) {
+    if (dep in pkg[section]) {
+      fail(
+        `"${dep}" is listed in "${section}" in package.json.\n` +
+        `  This would install a separate copy under SSI, breaking event emitter\n` +
+        `  identity with the customer's @openfeature/server-sdk.\n` +
+        `  See https://github.com/DataDog/dd-trace-js/pull/9570 for context.\n` +
+        `  If you need OpenFeature types, keep them in "devDependencies" only.`
+      )
+    }
+  }
+}
+
+// --- Check compiled .js files for runtime @openfeature imports ---
+function checkDir(dir, label) {
+  if (!fs.existsSync(dir)) return
+  for (const file of fs.readdirSync(dir)) {
+    if (!file.endsWith('.js')) continue
+    const content = fs.readFileSync(path.join(dir, file), 'utf8')
+    // Match require('@openfeature/...') or from '@openfeature/...'
+    if (content.includes("@openfeature/")) {
+      fail(
+        `Runtime @openfeature import found in ${label}/${file}.\n` +
+        `  The compiled output must not import from @openfeature/* at runtime.\n` +
+        `  All OpenFeature types must be import type only (erased at compile time)\n` +
+        `  and the event emitter must use the custom NodeProviderEventEmitter.`
+      )
+    }
+  }
+}
+
+checkDir(CJS_DIR, 'cjs')
+checkDir(ESM_DIR, 'esm')
+
+if (failed) {
+  console.error(
+    '\n\x1b[31m[verify-no-openfeature-dep] ' +
+    'Publishing blocked. @openfeature/server-sdk must remain a devDependency ' +
+    'only. Adding it as a runtime dependency breaks SSI compatibility with ' +
+    'dd-trace-js (see https://github.com/DataDog/dd-trace-js/pull/9570).\x1b[0m\n'
+  )
+  process.exit(1)
+} else {
+  console.log('\x1b[32m[verify-no-openfeature-dep] OK — no runtime @openfeature dependency.\x1b[0m')
+}

--- a/packages/node-server/src/provider-event-emitter.ts
+++ b/packages/node-server/src/provider-event-emitter.ts
@@ -1,0 +1,83 @@
+import { EventEmitter } from 'node:events'
+import type {
+  AnyProviderEvent,
+  EventContext,
+  EventHandler,
+  Logger,
+  ProviderEventEmitter,
+  ServerProviderEvents,
+} from '@openfeature/core'
+
+/**
+ * OpenFeature-compatible event emitter that does not require an OpenFeature SDK at runtime.
+ */
+export class NodeProviderEventEmitter implements ProviderEventEmitter<ServerProviderEvents> {
+  private readonly eventEmitter = new EventEmitter()
+  private readonly handlers = new Map<AnyProviderEvent, Map<EventHandler, EventHandler[]>>()
+  private logger?: Logger
+
+  emit(eventType: ServerProviderEvents, context?: EventContext): void {
+    this.eventEmitter.emit(eventType, context)
+  }
+
+  addHandler(eventType: AnyProviderEvent, handler: EventHandler): void {
+    const asyncHandler: EventHandler = async (details) => {
+      try {
+        await handler(details)
+      } catch (error) {
+        this.logHandlerError(error)
+      }
+    }
+
+    const handlersForEvent = this.handlers.get(eventType) ?? new Map<EventHandler, EventHandler[]>()
+    const registeredHandlers = handlersForEvent.get(handler) ?? []
+    registeredHandlers.push(asyncHandler)
+    handlersForEvent.set(handler, registeredHandlers)
+    this.handlers.set(eventType, handlersForEvent)
+    this.eventEmitter.on(eventType, asyncHandler)
+  }
+
+  removeHandler(eventType: AnyProviderEvent, handler: EventHandler): void {
+    const handlersForEvent = this.handlers.get(eventType)
+    const registeredHandlers = handlersForEvent?.get(handler)
+    const registeredHandler = registeredHandlers?.pop()
+
+    if (registeredHandler) {
+      this.eventEmitter.removeListener(eventType, registeredHandler)
+    }
+    if (registeredHandlers?.length === 0) {
+      handlersForEvent?.delete(handler)
+    }
+    if (handlersForEvent?.size === 0) {
+      this.handlers.delete(eventType)
+    }
+  }
+
+  removeAllHandlers(eventType?: AnyProviderEvent): void {
+    if (eventType) {
+      this.eventEmitter.removeAllListeners(eventType)
+      this.handlers.delete(eventType)
+      return
+    }
+
+    this.eventEmitter.removeAllListeners()
+    this.handlers.clear()
+  }
+
+  getHandlers(eventType: AnyProviderEvent): EventHandler[] {
+    return this.eventEmitter.listeners(eventType) as EventHandler[]
+  }
+
+  setLogger(logger: Logger): this {
+    this.logger = logger
+    return this
+  }
+
+  private logHandlerError(error: unknown): void {
+    try {
+      this.logger?.error('Error running event handler:', error)
+    } catch {
+      // A user-provided logger must not interrupt event delivery.
+    }
+  }
+}

--- a/packages/node-server/src/provider.ts
+++ b/packages/node-server/src/provider.ts
@@ -6,7 +6,7 @@ import {
   LRUInMemoryAssignmentCache,
   timeStampNow,
 } from '@datadog/flagging-core'
-import type { EvaluationContext } from '@openfeature/core'
+import type { EvaluationContext, ServerProviderEvents } from '@openfeature/core'
 import type {
   EvaluationDetails,
   FlagValue,
@@ -19,10 +19,16 @@ import type {
   ProviderMetadata,
   ResolutionDetails,
 } from '@openfeature/server-sdk'
-import { OpenFeatureEventEmitter, ProviderEvents } from '@openfeature/server-sdk'
 import { evaluate } from './configuration/evaluation'
 import type { UniversalFlagConfigurationV1 } from './configuration/ufc-v1'
 import { InitializationController } from './initialization-controller'
+import { NodeProviderEventEmitter } from './provider-event-emitter'
+
+const PROVIDER_EVENTS = {
+  ConfigurationChanged: 'PROVIDER_CONFIGURATION_CHANGED' as ServerProviderEvents.ConfigurationChanged,
+  Error: 'PROVIDER_ERROR' as ServerProviderEvents.Error,
+  Ready: 'PROVIDER_READY' as ServerProviderEvents.Ready,
+}
 
 /**
  * Default timeout in milliseconds for provider initialization.
@@ -50,14 +56,14 @@ export class DatadogNodeServerProvider implements Provider {
   readonly hooks?: Hook[]
 
   private initController?: InitializationController
-  readonly events: ProviderEventEmitter<ProviderEvents>
+  readonly events: ProviderEventEmitter<ServerProviderEvents>
   private readonly exposureCache: AssignmentCache | undefined
 
   private configuration?: UniversalFlagConfigurationV1 | undefined
 
   constructor(private readonly options: DatadogNodeServerProviderOptions) {
     this.hooks = []
-    this.events = new OpenFeatureEventEmitter()
+    this.events = new NodeProviderEventEmitter()
     this.exposureCache = new LRUInMemoryAssignmentCache(50_000)
   }
 
@@ -76,7 +82,7 @@ export class DatadogNodeServerProvider implements Provider {
     const hadConfiguration = !!this.configuration
 
     if (hadConfiguration && this.configuration !== configuration) {
-      this.events.emit(ProviderEvents.ConfigurationChanged)
+      this.events.emit(PROVIDER_EVENTS.ConfigurationChanged)
       const newCreatedAt = configuration?.createdAt
       if (prevCreatedAt !== newCreatedAt) {
         this.exposureCache?.clear()
@@ -94,7 +100,7 @@ export class DatadogNodeServerProvider implements Provider {
     } else if (!hadConfiguration) {
       // Configuration is being set after initialization completed/failed (e.g., after timeout)
       // Emit PROVIDER_READY to signal recovery from error state
-      this.events.emit(ProviderEvents.Ready)
+      this.events.emit(PROVIDER_EVENTS.Ready)
     }
   }
 
@@ -105,7 +111,7 @@ export class DatadogNodeServerProvider implements Provider {
     if (this.initController?.isInitializing()) {
       this.initController.fail(error)
     } else {
-      this.events.emit(ProviderEvents.Error, { error })
+      this.events.emit(PROVIDER_EVENTS.Error, { error })
     }
   }
 

--- a/packages/node-server/test/provider-event-emitter.spec.ts
+++ b/packages/node-server/test/provider-event-emitter.spec.ts
@@ -162,9 +162,7 @@ describe('NodeProviderEventEmitter', () => {
     })
 
     it('does not throw when removing a handler that was never registered', () => {
-      expect(() =>
-        emitter.removeHandler(ServerProviderEvents.Ready, jest.fn()),
-      ).not.toThrow()
+      expect(() => emitter.removeHandler(ServerProviderEvents.Ready, jest.fn())).not.toThrow()
     })
 
     it('does not affect handlers registered for other events', () => {

--- a/packages/node-server/test/provider-event-emitter.spec.ts
+++ b/packages/node-server/test/provider-event-emitter.spec.ts
@@ -1,0 +1,298 @@
+import type { EventHandler, Logger } from '@openfeature/core'
+import { ServerProviderEvents } from '@openfeature/core'
+import { NodeProviderEventEmitter } from '../src/provider-event-emitter'
+
+describe('NodeProviderEventEmitter', () => {
+  let emitter: NodeProviderEventEmitter
+  let logger: jest.Mocked<Logger>
+
+  beforeEach(() => {
+    emitter = new NodeProviderEventEmitter()
+    logger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    }
+  })
+
+  afterEach(() => {
+    emitter.removeAllHandlers()
+  })
+
+  describe('emit / addHandler', () => {
+    it('invokes a registered handler when the event is emitted', () => {
+      const handler = jest.fn()
+      emitter.addHandler(ServerProviderEvents.Ready, handler)
+
+      emitter.emit(ServerProviderEvents.Ready)
+
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it('passes the emitted context to the handler', () => {
+      const handler = jest.fn()
+      emitter.addHandler(ServerProviderEvents.ConfigurationChanged, handler)
+
+      const context = { flagsChanged: ['a', 'b'] }
+      emitter.emit(ServerProviderEvents.ConfigurationChanged, context)
+
+      expect(handler).toHaveBeenCalledWith(context)
+    })
+
+    it('calls multiple handlers for the same event in registration order', () => {
+      const order: string[] = []
+      const first = jest.fn(() => order.push('first'))
+      const second = jest.fn(() => order.push('second'))
+
+      emitter.addHandler(ServerProviderEvents.Ready, first)
+      emitter.addHandler(ServerProviderEvents.Ready, second)
+      emitter.emit(ServerProviderEvents.Ready)
+
+      expect(order).toEqual(['first', 'second'])
+    })
+
+    it('does not invoke handlers registered for a different event', () => {
+      const handler = jest.fn()
+      emitter.addHandler(ServerProviderEvents.Ready, handler)
+
+      emitter.emit(ServerProviderEvents.Stale)
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('invokes the handler once per emit for each time it was added', () => {
+      const handler = jest.fn()
+      emitter.addHandler(ServerProviderEvents.Ready, handler)
+      emitter.addHandler(ServerProviderEvents.Ready, handler)
+
+      emitter.emit(ServerProviderEvents.Ready)
+      expect(handler).toHaveBeenCalledTimes(2)
+
+      emitter.emit(ServerProviderEvents.Ready)
+      expect(handler).toHaveBeenCalledTimes(4)
+    })
+  })
+
+  describe('handler error isolation', () => {
+    it('does not let a throwing sync handler interrupt emit or other handlers', () => {
+      const second = jest.fn()
+      emitter.addHandler(ServerProviderEvents.Error, () => {
+        throw new Error('boom')
+      })
+      emitter.addHandler(ServerProviderEvents.Error, second)
+
+      expect(() => emitter.emit(ServerProviderEvents.Error)).not.toThrow()
+
+      expect(second).toHaveBeenCalledTimes(1)
+    })
+
+    it('logs handler errors through the configured logger', () => {
+      const error = new Error('boom')
+      emitter.setLogger(logger)
+      emitter.addHandler(ServerProviderEvents.Error, () => {
+        throw error
+      })
+
+      emitter.emit(ServerProviderEvents.Error)
+
+      expect(logger.error).toHaveBeenCalledTimes(1)
+      expect(logger.error).toHaveBeenCalledWith('Error running event handler:', error)
+    })
+
+    it('does not throw when no logger is set and a handler errors', () => {
+      emitter.addHandler(ServerProviderEvents.Error, () => {
+        throw new Error('boom')
+      })
+
+      expect(() => emitter.emit(ServerProviderEvents.Error)).not.toThrow()
+    })
+
+    it('logs errors from async handlers that reject', async () => {
+      const error = new Error('async boom')
+      emitter.setLogger(logger)
+      emitter.addHandler(ServerProviderEvents.Error, () => Promise.reject(error))
+
+      emitter.emit(ServerProviderEvents.Error)
+      // The async wrapper awaits the rejected promise inside its try/catch; flush
+      // the microtask queue so the catch branch (and logger call) can run.
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(logger.error).toHaveBeenCalledTimes(1)
+      expect(logger.error).toHaveBeenCalledWith('Error running event handler:', error)
+    })
+
+    it('swallows errors thrown by the logger itself so delivery is not interrupted', () => {
+      const second = jest.fn()
+      logger.error.mockImplementation(() => {
+        throw new Error('logger is broken')
+      })
+      emitter.setLogger(logger)
+      emitter.addHandler(ServerProviderEvents.Error, () => {
+        throw new Error('handler boom')
+      })
+      emitter.addHandler(ServerProviderEvents.Error, second)
+
+      expect(() => emitter.emit(ServerProviderEvents.Error)).not.toThrow()
+      expect(second).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('removeHandler', () => {
+    it('stops a registered handler from being invoked', () => {
+      const handler = jest.fn()
+      emitter.addHandler(ServerProviderEvents.Ready, handler)
+      emitter.removeHandler(ServerProviderEvents.Ready, handler)
+
+      emitter.emit(ServerProviderEvents.Ready)
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('only removes one instance when the same handler was added multiple times (LIFO)', () => {
+      const handler = jest.fn()
+      emitter.addHandler(ServerProviderEvents.Ready, handler)
+      emitter.addHandler(ServerProviderEvents.Ready, handler)
+      emitter.removeHandler(ServerProviderEvents.Ready, handler)
+
+      emitter.emit(ServerProviderEvents.Ready)
+
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not throw when removing a handler that was never registered', () => {
+      expect(() =>
+        emitter.removeHandler(ServerProviderEvents.Ready, jest.fn()),
+      ).not.toThrow()
+    })
+
+    it('does not affect handlers registered for other events', () => {
+      const readyHandler = jest.fn()
+      const staleHandler = jest.fn()
+      emitter.addHandler(ServerProviderEvents.Ready, readyHandler)
+      emitter.addHandler(ServerProviderEvents.Stale, staleHandler)
+
+      emitter.removeHandler(ServerProviderEvents.Ready, readyHandler)
+      emitter.emit(ServerProviderEvents.Stale)
+
+      expect(staleHandler).toHaveBeenCalledTimes(1)
+    })
+
+    it('reports no handlers via getHandlers once all handlers for an event are removed', () => {
+      const handler = jest.fn()
+      emitter.addHandler(ServerProviderEvents.Ready, handler)
+      emitter.removeHandler(ServerProviderEvents.Ready, handler)
+
+      expect(emitter.getHandlers(ServerProviderEvents.Ready)).toEqual([])
+    })
+  })
+
+  describe('removeAllHandlers', () => {
+    it('removes only the handlers for the given event type', () => {
+      const readyHandler = jest.fn()
+      const staleHandler = jest.fn()
+      emitter.addHandler(ServerProviderEvents.Ready, readyHandler)
+      emitter.addHandler(ServerProviderEvents.Stale, staleHandler)
+
+      emitter.removeAllHandlers(ServerProviderEvents.Ready)
+      emitter.emit(ServerProviderEvents.Ready)
+      emitter.emit(ServerProviderEvents.Stale)
+
+      expect(readyHandler).not.toHaveBeenCalled()
+      expect(staleHandler).toHaveBeenCalledTimes(1)
+      expect(emitter.getHandlers(ServerProviderEvents.Stale)).toHaveLength(1)
+    })
+
+    it('removes handlers for every event when called with no argument', () => {
+      const readyHandler = jest.fn()
+      const staleHandler = jest.fn()
+      emitter.addHandler(ServerProviderEvents.Ready, readyHandler)
+      emitter.addHandler(ServerProviderEvents.Stale, staleHandler)
+
+      emitter.removeAllHandlers()
+      emitter.emit(ServerProviderEvents.Ready)
+      emitter.emit(ServerProviderEvents.Stale)
+
+      expect(readyHandler).not.toHaveBeenCalled()
+      expect(staleHandler).not.toHaveBeenCalled()
+      expect(emitter.getHandlers(ServerProviderEvents.Ready)).toEqual([])
+      expect(emitter.getHandlers(ServerProviderEvents.Stale)).toEqual([])
+    })
+
+    it('allows re-registering handlers after removing all for an event', () => {
+      const handler = jest.fn()
+      emitter.addHandler(ServerProviderEvents.Ready, handler)
+      emitter.removeAllHandlers(ServerProviderEvents.Ready)
+      emitter.addHandler(ServerProviderEvents.Ready, handler)
+
+      emitter.emit(ServerProviderEvents.Ready)
+
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('getHandlers', () => {
+    it('returns an empty array for an event with no registered handlers', () => {
+      expect(emitter.getHandlers(ServerProviderEvents.Ready)).toEqual([])
+    })
+
+    it('returns one entry per registered handler instance', () => {
+      const first = jest.fn()
+      const second = jest.fn()
+      emitter.addHandler(ServerProviderEvents.Ready, first)
+      emitter.addHandler(ServerProviderEvents.Ready, second)
+
+      expect(emitter.getHandlers(ServerProviderEvents.Ready)).toHaveLength(2)
+    })
+
+    it('returns the wrapped listeners, not the original handler references', () => {
+      const handler: EventHandler = jest.fn()
+      emitter.addHandler(ServerProviderEvents.Ready, handler)
+
+      const handlers = emitter.getHandlers(ServerProviderEvents.Ready)
+      expect(handlers).toHaveLength(1)
+      expect(handlers[0]).not.toBe(handler)
+    })
+  })
+
+  describe('setLogger', () => {
+    it('returns the emitter instance for chaining', () => {
+      expect(emitter.setLogger(logger)).toBe(emitter)
+    })
+
+    it('uses the most recently set logger for handler errors', () => {
+      const firstLogger: jest.Mocked<Logger> = {
+        error: jest.fn(),
+        warn: jest.fn(),
+        info: jest.fn(),
+        debug: jest.fn(),
+      }
+      emitter.setLogger(firstLogger)
+      emitter.addHandler(ServerProviderEvents.Error, () => {
+        throw new Error('first')
+      })
+      emitter.emit(ServerProviderEvents.Error)
+
+      expect(firstLogger.error).toHaveBeenCalledTimes(1)
+
+      const secondLogger: jest.Mocked<Logger> = {
+        error: jest.fn(),
+        warn: jest.fn(),
+        info: jest.fn(),
+        debug: jest.fn(),
+      }
+      emitter.setLogger(secondLogger)
+      emitter.addHandler(ServerProviderEvents.Error, () => {
+        throw new Error('second')
+      })
+      emitter.emit(ServerProviderEvents.Error)
+
+      // Both the previously-registered and newly-registered handlers run on the
+      // second emit, and both route errors to the now-current (second) logger.
+      expect(secondLogger.error).toHaveBeenCalledTimes(2)
+      // The first logger is no longer active, so it is not touched again.
+      expect(firstLogger.error).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/scripts/test-node-package-install.sh
+++ b/scripts/test-node-package-install.sh
@@ -57,11 +57,16 @@ cat > package.json << 'PKGJSON'
   "private": true,
   "description": "Test app for validating @datadog/openfeature-node-server installation scenarios",
   "scripts": {
-    "test": "node test.js"
+    "test": "node test.js",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@datadog/flagging-core": "file:./core.tgz",
     "@datadog/openfeature-node-server": "file:./node-server.tgz"
+  },
+  "devDependencies": {
+    "@types/node": "^18.19.130",
+    "typescript": "^5.9.3"
   }
 }
 PKGJSON
@@ -127,9 +132,15 @@ fi
 
 node "$REPO_ROOT/scripts/assert-node-package-purity.js" node_modules
 
-# Run tests
+# Run TypeScript type check (verifies bundled index.d.ts compiles from a consumer perspective)
 echo ""
-echo "Running tests..."
+echo "Running TypeScript type check..."
+echo ""
+yarn typecheck
+
+# Run runtime tests
+echo ""
+echo "Running runtime tests..."
 echo ""
 yarn test
 

--- a/test-app-node/package.json
+++ b/test-app-node/package.json
@@ -4,12 +4,15 @@
   "private": true,
   "description": "Test app for validating @datadog/openfeature-node-server installation scenarios",
   "scripts": {
-    "test": "node test.js"
+    "test": "node test.js",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@datadog/flagging-core": "file:./core.tgz",
-    "@datadog/openfeature-node-server": "file:./node-server.tgz",
-    "@openfeature/core": "1.9.2",
-    "@openfeature/server-sdk": "1.15.1"
+    "@datadog/openfeature-node-server": "file:./node-server.tgz"
+  },
+  "devDependencies": {
+    "@types/node": "^18.19.130",
+    "typescript": "^5.9.3"
   }
 }

--- a/test-app-node/tsconfig.json
+++ b/test-app-node/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["ES2020"],
+    "types": ["node"],
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["typecheck.ts"]
+}

--- a/test-app-node/typecheck.ts
+++ b/test-app-node/typecheck.ts
@@ -78,5 +78,25 @@ provider.setError(new Error('test error'))
 // --- Test 10: initialize returns a Promise<void> ---
 const initPromise: Promise<void> = provider.initialize()
 
+// --- Test 11: Provider is compatible with OpenFeature.setProvider ---
+// Verifies that our provider can be registered with the OpenFeature SDK without
+// type errors. This is the key integration point: if the bundled type
+// declarations drift from the Provider interface that @openfeature/server-sdk
+// expects, this call will fail to compile.
+//
+// This test only type-checks when @openfeature/server-sdk is installed (normal
+// consumer scenario). In the SSI/dd-trace scenario where the SDK is absent, the
+// @ts-ignore below suppresses the missing-module error and OpenFeature resolves
+// to `any`, making the call a type-check no-op.
+//
+// Run against the minimum supported SDK version to catch regressions early:
+//   OF_SERVER_SDK_VERSION=1.15.0 OF_CORE_VERSION=1.3.0 \
+//     yarn test:node-install:with-of
+//
+// @ts-ignore: @openfeature/server-sdk may not be installed (SSI/dd-trace scenario)
+import { OpenFeature } from '@openfeature/server-sdk'
+
+OpenFeature.setProvider(provider)
+
 // Verify all bindings are used (no unused variable errors with strict mode)
 void [providerName, runsOn, events, hooks, initPromise]

--- a/test-app-node/typecheck.ts
+++ b/test-app-node/typecheck.ts
@@ -1,0 +1,82 @@
+/**
+ * TypeScript consumer test for @datadog/openfeature-node-server.
+ *
+ * Verifies that the bundled index.d.ts type declarations compile correctly
+ * from a consumer's perspective. This test must pass in BOTH scenarios:
+ *
+ * 1. WITHOUT @openfeature/server-sdk installed (SSI / dd-trace scenario):
+ *    The bundled index.d.ts should be self-contained with no @openfeature/*
+ *    references. A consumer who only has dd-trace (not the OF SDK) must be
+ *    able to import and use the provider without TypeScript errors.
+ *
+ * 2. WITH @openfeature/server-sdk installed (normal consumer scenario):
+ *    The provider should be compatible with the OpenFeature SDK's types.
+ *
+ * This catches issues that dts-bundle-generator might introduce:
+ * - Dangling @openfeature/* type references in the bundled index.d.ts
+ * - Missing or incompatible inlined types
+ * - Broken re-exports from @datadog/flagging-core
+ */
+
+import diagnostics_channel from 'node:diagnostics_channel'
+import {
+  DatadogNodeServerProvider,
+  type DatadogNodeServerProviderOptions,
+  type UniversalFlagConfigurationV1,
+} from '@datadog/openfeature-node-server'
+
+// --- Test 1: DatadogNodeServerProvider can be instantiated with correct options ---
+// Consumers get the channel from diagnostics_channel.channel() (returns Channel<unknown, unknown>)
+// and must cast to the type expected by the provider options.
+const exposureChannel = diagnostics_channel.channel(
+  'dd-trace:openfeature:exposure'
+) as DatadogNodeServerProviderOptions['exposureChannel']
+
+const options: DatadogNodeServerProviderOptions = {
+  exposureChannel,
+  initializationTimeoutMs: 5000,
+}
+
+const provider = new DatadogNodeServerProvider(options)
+
+// --- Test 2: Provider metadata is properly typed ---
+const providerName: string = provider.metadata.name
+
+// --- Test 3: Paradigm type is inlined correctly ---
+const runsOn: 'server' | 'client' = provider.runsOn
+
+// --- Test 4: Events emitter is accessible and typed ---
+const events = provider.events
+
+// --- Test 5: Hooks array is accessible ---
+const hooks = provider.hooks
+
+// --- Test 6: UniversalFlagConfigurationV1 type is usable and correctly shaped ---
+const config: UniversalFlagConfigurationV1 = {
+  createdAt: '2024-01-01T00:00:00Z',
+  format: 'universal-flag-configuration',
+  environment: {
+    name: 'production',
+  },
+  flags: {},
+}
+
+// --- Test 7: setConfiguration accepts the correct type ---
+provider.setConfiguration(config)
+
+// --- Test 8: getConfiguration returns the correct type ---
+const retrieved = provider.getConfiguration()
+if (retrieved) {
+  const createdAt: string = retrieved.createdAt
+  const format: string = retrieved.format
+  void [createdAt, format]
+}
+
+// --- Test 9: setError accepts unknown ---
+provider.setError(new Error('test error'))
+
+// --- Test 10: initialize returns a Promise<void> ---
+const initPromise: Promise<void> = provider.initialize()
+
+// Verify all bindings are used (no unused variable errors with strict mode)
+void [providerName, runsOn, events, hooks, initPromise]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2786,15 +2786,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-base@npm:6":
-  version: 6.0.2
-  resolution: "agent-base@npm:6.0.2"
-  dependencies:
-    debug: "npm:4"
-  checksum: 10c0/dc4f757e40b5f3e3d674bc9beb4f1048f4ee83af189bae39be99f57bf1f48dde166a8b0a5342a84b5944ee8e6ed1e5a9d801858f4ad44764e84957122fe46261
-  languageName: node
-  linkType: hard
-
 "agent-base@npm:^7.1.0, agent-base@npm:^7.1.2":
   version: 7.1.4
   resolution: "agent-base@npm:7.1.4"
@@ -3021,14 +3012,13 @@ __metadata:
   linkType: hard
 
 "axios@npm:^1.12.0":
-  version: 1.19.0
-  resolution: "axios@npm:1.19.0"
+  version: 1.15.0
+  resolution: "axios@npm:1.15.0"
   dependencies:
-    follow-redirects: "npm:^1.16.0"
-    form-data: "npm:^4.0.6"
-    https-proxy-agent: "npm:^5.0.1"
+    follow-redirects: "npm:^1.15.11"
+    form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/559fe7d51291787def61566a3db78b87510c8faf9c8a8c006d9d8b933808628ff0d8eca7756b40ae25e07da96d946c68c1ffba3da9075ed0b5d3661801d76869
+  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
   languageName: node
   linkType: hard
 
@@ -3191,16 +3181,25 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.18
-  resolution: "brace-expansion@npm:1.1.18"
+  version: 1.1.12
+  resolution: "brace-expansion@npm:1.1.12"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/3432c18a9e2ebf94162d4effb62198bd0adea06a9f332b2c0188df5d5e30b1e51ea3c848b6608e47d0b857ebe1ea5b3888ed3326dd3c4f6f9645c94153cf9c14
+  checksum: 10c0/975fecac2bb7758c062c20d0b3b6288c7cc895219ee25f0a64a9de662dbac981ff0b6e89909c3897c1f84fa353113a721923afdec5f8b2350255b097f12b1f73
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
+"brace-expansion@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "brace-expansion@npm:2.0.2"
+  dependencies:
+    balanced-match: "npm:^1.0.0"
+  checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^2.0.2":
   version: 2.1.4
   resolution: "brace-expansion@npm:2.1.4"
   dependencies:
@@ -4523,9 +4522,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.5
-  resolution: "fast-uri@npm:3.1.5"
-  checksum: 10c0/2bf60eb800dd610c65e17be436425dcb21c92aff3a87d442a8bccab0b7b071e88cf1a5d7d1ea946370b937e6fc0375c405c0296c10587e57de4f78be4646d1d0
+  version: 3.0.6
+  resolution: "fast-uri@npm:3.0.6"
+  checksum: 10c0/74a513c2af0584448aee71ce56005185f81239eab7a2343110e5bad50c39ad4fb19c5a6f99783ead1cac7ccaf3461a6034fda89fffa2b30b6d99b9f21c2f9d29
   languageName: node
   linkType: hard
 
@@ -4605,7 +4604,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.16.0":
+"follow-redirects@npm:^1.15.11":
   version: 1.16.0
   resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
@@ -4634,16 +4633,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.6":
-  version: 4.0.6
-  resolution: "form-data@npm:4.0.6"
+"form-data@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "form-data@npm:4.0.5"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.4"
-    mime-types: "npm:^2.1.35"
-  checksum: 10c0/43947a77bf0ff45c6ceed789778982d47a3f3e720a74b71721174ebf3310a5f1a8be1d6b38a3ee3688e8a18a2c4273073ec0844cd37efda3eaf46d41c9c318ff
+    hasown: "npm:^2.0.2"
+    mime-types: "npm:^2.1.12"
+  checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
   languageName: node
   linkType: hard
 
@@ -5072,12 +5071,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hasown@npm:^2.0.2, hasown@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "hasown@npm:2.0.4"
+"hasown@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "hasown@npm:2.0.2"
   dependencies:
     function-bind: "npm:^1.1.2"
-  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
+  checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
   languageName: node
   linkType: hard
 
@@ -5154,16 +5153,6 @@ __metadata:
     agent-base: "npm:^7.1.0"
     debug: "npm:^4.3.4"
   checksum: 10c0/4207b06a4580fb85dd6dff521f0abf6db517489e70863dca1a0291daa7f2d3d2d6015a57bd702af068ea5cf9f1f6ff72314f5f5b4228d299c0904135d2aef921
-  languageName: node
-  linkType: hard
-
-"https-proxy-agent@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "https-proxy-agent@npm:5.0.1"
-  dependencies:
-    agent-base: "npm:6"
-    debug: "npm:4"
-  checksum: 10c0/6dd639f03434003577c62b27cafdb864784ef19b2de430d8ae2a1d45e31c4fd60719e5637b44db1a88a046934307da7089e03d6089ec3ddacc1189d8de8897d1
   languageName: node
   linkType: hard
 
@@ -6904,7 +6893,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.35":
+"mime-types@npm:^2.1.12":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -6927,7 +6916,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:3.1.4, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
+"minimatch@npm:3.1.4":
   version: 3.1.4
   resolution: "minimatch@npm:3.1.4"
   dependencies:
@@ -6942,6 +6931,15 @@ __metadata:
   dependencies:
     brace-expansion: "npm:^5.0.8"
   checksum: 10c0/4559a836243b98bd4d17ea9f7edae698717c76399eea7be374f3737f33164e4907f19e9726891ddeb122f750a5a7fa80d2ac43e851d6e5984dc4ff42ec127d3a
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
+  dependencies:
+    brace-expansion: "npm:^1.1.7"
+  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
   languageName: node
   linkType: hard
 
@@ -7965,9 +7963,9 @@ __metadata:
   linkType: hard
 
 "picomatch@npm:^4.0.2, picomatch@npm:^4.0.3":
-  version: 4.0.5
-  resolution: "picomatch@npm:4.0.5"
-  checksum: 10c0/947bc6b6e1ff1e6c5aaf95b107a0839d12802f4f7b867663f67d47accba939ca1cb582cf99dfc30438efa1c4648ac5990967e783e8929c36b03e8440704ef1bd
+  version: 4.0.3
+  resolution: "picomatch@npm:4.0.3"
+  checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
   languageName: node
   linkType: hard
 
@@ -9538,7 +9536,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.9.3":
+"typescript@npm:5.9.3, typescript@npm:>=3 < 6, typescript@npm:^5.5.0, typescript@npm:^5.9.3":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
   bin:
@@ -9548,7 +9546,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A>=3 < 6#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.5.0#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
@@ -9594,9 +9592,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^7.24.5":
-  version: 7.29.0
-  resolution: "undici@npm:7.29.0"
-  checksum: 10c0/85ea96e91e7f3de24de678cbbc54230fdd641a3b0643005f2aef044af1f1a2db8fbecb88b28e6fa78bb41ffeafda4479b57075b6b6ab92beac4b7b5ab53f9b10
+  version: 7.24.5
+  resolution: "undici@npm:7.24.5"
+  checksum: 10c0/2a836f1f6ab078fde3eeb4cc8fd5b34eeaf52cfbdf16a9bab61b7223f43f7847bcd2125d1da7c4e3f5996c528bf9f7940015d39909bab80cfbd71b855470cf21
   languageName: node
   linkType: hard
 
@@ -10122,8 +10120,8 @@ __metadata:
   linkType: hard
 
 "ws@npm:^8.18.0":
-  version: 8.21.1
-  resolution: "ws@npm:8.21.1"
+  version: 8.18.3
+  resolution: "ws@npm:8.18.3"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -10132,7 +10130,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/c4c6f1d95f6d465262de2037c57c715725d67e078dd49420ede4e19115668aba159cb64d85c5e89c06eb2826be599e62e5095860ad6cc54ff42e8bd7684e1db8
+  checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -744,6 +744,7 @@ __metadata:
     "@openfeature/server-sdk": "npm:1.20.2"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^18.19.130"
+    dts-bundle-generator: "npm:^9.0.0"
     jest: "npm:^30.0.5"
     npm-run-all: "npm:^4.1.5"
     ts-jest: "npm:^29.4.9"
@@ -4090,6 +4091,18 @@ __metadata:
   version: 16.4.7
   resolution: "dotenv@npm:16.4.7"
   checksum: 10c0/be9f597e36a8daf834452daa1f4cc30e5375a5968f98f46d89b16b983c567398a330580c88395069a77473943c06b877d1ca25b4afafcdd6d4adb549e8293462
+  languageName: node
+  linkType: hard
+
+"dts-bundle-generator@npm:^9.0.0":
+  version: 9.5.1
+  resolution: "dts-bundle-generator@npm:9.5.1"
+  dependencies:
+    typescript: "npm:>=5.0.2"
+    yargs: "npm:^17.6.0"
+  bin:
+    dts-bundle-generator: dist/bin/dts-bundle-generator.js
+  checksum: 10c0/3685d3797b6cd252c5a27174a504193469e2a8d82188224767e522e2e8eb03de431107836232a0ac89bcfbc38caa0dcf2ec7fb81716e781185f8ea840b956bc2
   languageName: node
   linkType: hard
 
@@ -9525,7 +9538,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:>=3 < 6, typescript@npm:^5.5.0, typescript@npm:^5.9.3":
+"typescript@npm:5.9.3":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
   bin:
@@ -9535,7 +9548,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A>=3 < 6#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.5.0#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
@@ -10222,6 +10235,21 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^20.2.2"
   checksum: 10c0/b1dbfefa679848442454b60053a6c95d62f2d2e21dd28def92b647587f415969173c6e99a0f3bab4f1b67ee8283bf735ebe3544013f09491186ba9e8a9a2b651
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.6.0":
+  version: 17.7.3
+  resolution: "yargs@npm:17.7.3"
+  dependencies:
+    cliui: "npm:^8.0.1"
+    escalade: "npm:^3.1.1"
+    get-caller-file: "npm:^2.0.5"
+    require-directory: "npm:^2.1.1"
+    string-width: "npm:^4.2.3"
+    y18n: "npm:^5.0.5"
+    yargs-parser: "npm:^21.1.1"
+  checksum: 10c0/7a28572f7e785a57886e34fdbddb9b28756dec552e1453d5f6e7cdd00ad8721a4e8c4321d33683f5e61cacb36ad43258adbb48396b71ec4ed14abee0fc0d0c1f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -749,8 +749,6 @@ __metadata:
     ts-jest: "npm:^29.4.9"
     ts-loader: "npm:^9.5.7"
     typescript: "npm:^5.9.3"
-  peerDependencies:
-    "@openfeature/server-sdk": ">=1.15.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## What

At a high-level, this PR removes `@openfeature/server-sdk` as a runtime dependency.

- **Custom EventEmitter** — replaces `OpenFeatureEventEmitter` from `@openfeature/server-sdk` with a custom `NodeProviderEventEmitter` built on Node's native `EventEmitter`. Zero `@openfeature` imports in compiled `.js`.
- **Bundled type declarations** — `dts-bundle-generator` inlines all `@openfeature/core` and `@openfeature/server-sdk` types into a single self-contained `index.d.ts` with zero `@openfeature` references. Necessary for SSI where `dd-trace`'s `node_modules` can't reach the customer's `@openfeature/server-sdk`.

## Why

`dd-trace-js` plans to vendor the OpenFeature provider to work around `@datadog/openfeature-node-server` having `@openfeature/server-sdk` as a peer dependency, which fails under SSI ([dd-trace-js#9570](https://github.com/DataDog/dd-trace-js/pull/9570)). This PR removes the `@openfeature/server-sdk` runtime dependency so `dd-trace-js` can instead declare `@datadog/openfeature-node-server` as a regular dependency.

This approach has several benefits:
- Reduces build complexity in dd-trace-js
- Allows for patch fixes to automatically reach customers, assuming dd-trace-js specifies this library as a patch-level range in its package.json.

## Details of why build:types is needed

### Why `build:types` is needed

`tsc` alone produces `.d.ts` files that preserve external imports:

```typescript
// cjs/provider.d.ts (tsc output)
import type { Provider, ResolutionDetails, ... } from "@openfeature/server-sdk";
import type { ServerProviderEvents, ... } from "@openfeature/core";
```

Under SSI, `dd-trace` is installed outside the application's `node_modules`, so these `.d.ts` files live in `dd-trace`'s `node_modules` tree. TypeScript resolves the `@openfeature/server-sdk` import by walking up from the `.d.ts` file's location — it never reaches the customer's `node_modules` where their `@openfeature/server-sdk` is actually installed:

```
/opt/datadog/dd-trace-js/                          ← dd-trace lives here
  node_modules/
    @datadog/openfeature-node-server/
      cjs/provider.d.ts                             ← .d.ts is here, can't resolve @openfeature/server-sdk

/home/user/my-app/                                  ← customer's app
  node_modules/
    @openfeature/server-sdk/                        ← customer's SDK is here, unreachable
```

`build:types` uses `dts-bundle-generator` to inline all `@openfeature/*` types into a single self-contained `index.d.ts` with zero external `@openfeature` imports, so the types resolve regardless of where `dd-trace` is installed.

See https://github.com/DataDog/dd-trace-js/pull/9570 for the SSI context.
