### PR TITLE
chore: typecheck for `test-node-app`

### DIFF
--- a/scripts/test-node-package-install.sh
+++ b/scripts/test-node-package-install.sh
@@ -57,11 +57,16 @@ cat > package.json << 'PKGJSON'
   "private": true,
   "description": "Test app for validating @datadog/openfeature-node-server installation scenarios",
   "scripts": {
-    "test": "node test.js"
+    "test": "node test.js",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@datadog/flagging-core": "file:./core.tgz",
     "@datadog/openfeature-node-server": "file:./node-server.tgz"
+  },
+  "devDependencies": {
+    "@types/node": "^18.19.130",
+    "typescript": "^5.9.3"
   }
 }
 PKGJSON
@@ -127,9 +132,15 @@ fi
 
 node "$REPO_ROOT/scripts/assert-node-package-purity.js" node_modules
 
-# Run tests
+# Run TypeScript type check (verifies bundled index.d.ts compiles from a consumer perspective)
 echo ""
-echo "Running tests..."
+echo "Running TypeScript type check..."
+echo ""
+yarn typecheck
+
+# Run runtime tests
+echo ""
+echo "Running runtime tests..."
 echo ""
 yarn test
 

--- a/test-app-node/package.json
+++ b/test-app-node/package.json
@@ -4,12 +4,15 @@
   "private": true,
   "description": "Test app for validating @datadog/openfeature-node-server installation scenarios",
   "scripts": {
-    "test": "node test.js"
+    "test": "node test.js",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@datadog/flagging-core": "file:./core.tgz",
-    "@datadog/openfeature-node-server": "file:./node-server.tgz",
-    "@openfeature/core": "1.9.2",
-    "@openfeature/server-sdk": "1.15.1"
+    "@datadog/openfeature-node-server": "file:./node-server.tgz"
+  },
+  "devDependencies": {
+    "@types/node": "^18.19.130",
+    "typescript": "^5.9.3"
   }
 }

--- a/test-app-node/tsconfig.json
+++ b/test-app-node/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["ES2020"],
+    "types": ["node"],
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["typecheck.ts"]
+}

--- a/test-app-node/typecheck.ts
+++ b/test-app-node/typecheck.ts
@@ -1,0 +1,82 @@
+/**
+ * TypeScript consumer test for @datadog/openfeature-node-server.
+ *
+ * Verifies that the bundled index.d.ts type declarations compile correctly
+ * from a consumer's perspective. This test must pass in BOTH scenarios:
+ *
+ * 1. WITHOUT @openfeature/server-sdk installed (SSI / dd-trace scenario):
+ *    The bundled index.d.ts should be self-contained with no @openfeature/*
+ *    references. A consumer who only has dd-trace (not the OF SDK) must be
+ *    able to import and use the provider without TypeScript errors.
+ *
+ * 2. WITH @openfeature/server-sdk installed (normal consumer scenario):
+ *    The provider should be compatible with the OpenFeature SDK's types.
+ *
+ * This catches issues that dts-bundle-generator might introduce:
+ * - Dangling @openfeature/* type references in the bundled index.d.ts
+ * - Missing or incompatible inlined types
+ * - Broken re-exports from @datadog/flagging-core
+ */
+
+import diagnostics_channel from 'node:diagnostics_channel'
+import {
+  DatadogNodeServerProvider,
+  type DatadogNodeServerProviderOptions,
+  type UniversalFlagConfigurationV1,
+} from '@datadog/openfeature-node-server'
+
+// --- Test 1: DatadogNodeServerProvider can be instantiated with correct options ---
+// Consumers get the channel from diagnostics_channel.channel() (returns Channel<unknown, unknown>)
+// and must cast to the type expected by the provider options.
+const exposureChannel = diagnostics_channel.channel(
+  'dd-trace:openfeature:exposure'
+) as DatadogNodeServerProviderOptions['exposureChannel']
+
+const options: DatadogNodeServerProviderOptions = {
+  exposureChannel,
+  initializationTimeoutMs: 5000,
+}
+
+const provider = new DatadogNodeServerProvider(options)
+
+// --- Test 2: Provider metadata is properly typed ---
+const providerName: string = provider.metadata.name
+
+// --- Test 3: Paradigm type is inlined correctly ---
+const runsOn: 'server' | 'client' = provider.runsOn
+
+// --- Test 4: Events emitter is accessible and typed ---
+const events = provider.events
+
+// --- Test 5: Hooks array is accessible ---
+const hooks = provider.hooks
+
+// --- Test 6: UniversalFlagConfigurationV1 type is usable and correctly shaped ---
+const config: UniversalFlagConfigurationV1 = {
+  createdAt: '2024-01-01T00:00:00Z',
+  format: 'universal-flag-configuration',
+  environment: {
+    name: 'production',
+  },
+  flags: {},
+}
+
+// --- Test 7: setConfiguration accepts the correct type ---
+provider.setConfiguration(config)
+
+// --- Test 8: getConfiguration returns the correct type ---
+const retrieved = provider.getConfiguration()
+if (retrieved) {
+  const createdAt: string = retrieved.createdAt
+  const format: string = retrieved.format
+  void [createdAt, format]
+}
+
+// --- Test 9: setError accepts unknown ---
+provider.setError(new Error('test error'))
+
+// --- Test 10: initialize returns a Promise<void> ---
+const initPromise: Promise<void> = provider.initialize()
+
+// Verify all bindings are used (no unused variable errors with strict mode)
+void [providerName, runsOn, events, hooks, initPromise]


### PR DESCRIPTION
Gated on https://github.com/DataDog/openfeature-js-client/pull/356

## Motivation

Ensure that typescript checks are available for the `test-node-app` when running `scripts/test-node-package-install.sh`

## Changes

Adds typechecks to custom `test-node-app`