### PR TITLE
fix(node-server): unref initialization timeout

### DIFF
--- a/packages/node-server/src/initialization-controller.ts
+++ b/packages/node-server/src/initialization-controller.ts
@@ -27,7 +27,7 @@ export class InitializationController {
         this.timeoutId = setTimeout(() => {
           onTimeout()
         }, timeoutMs)
-        this.timeoutId.unref()
+        this.timeoutId.unref?.()
       }),
     ])
   }

--- a/packages/node-server/src/initialization-controller.ts
+++ b/packages/node-server/src/initialization-controller.ts
@@ -27,6 +27,7 @@ export class InitializationController {
         this.timeoutId = setTimeout(() => {
           onTimeout()
         }, timeoutMs)
+        this.timeoutId.unref()
       }),
     ])
   }

--- a/packages/node-server/test/initialization-controller.spec.ts
+++ b/packages/node-server/test/initialization-controller.spec.ts
@@ -59,6 +59,20 @@ describe('InitializationController', () => {
     expect(onTimeout).toHaveBeenCalledTimes(1)
   })
 
+  it('should not keep the event loop active while initialization is pending', async () => {
+    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout')
+    const controller = new InitializationController(5000, jest.fn())
+    const timeout = setTimeoutSpy.mock.results[0].value
+
+    try {
+      expect(timeout.hasRef()).toBe(false)
+    } finally {
+      controller.complete()
+      await controller.wait()
+      setTimeoutSpy.mockRestore()
+    }
+  })
+
   it('should clear timeout when completed before timeout', async () => {
     jest.useFakeTimers()
     const onTimeout = jest.fn()

--- a/packages/node-server/test/initialization-controller.spec.ts
+++ b/packages/node-server/test/initialization-controller.spec.ts
@@ -73,6 +73,23 @@ describe('InitializationController', () => {
     }
   })
 
+  it('should support timer implementations without unref', async () => {
+    const timeout = 1 as unknown as NodeJS.Timeout
+    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout').mockReturnValue(timeout)
+    const clearTimeoutSpy = jest.spyOn(globalThis, 'clearTimeout').mockImplementation()
+
+    try {
+      const controller = new InitializationController(5000, jest.fn())
+      controller.complete()
+      await controller.wait()
+
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(timeout)
+    } finally {
+      setTimeoutSpy.mockRestore()
+      clearTimeoutSpy.mockRestore()
+    }
+  })
+
   it('should clear timeout when completed before timeout', async () => {
     jest.useFakeTimers()
     const onTimeout = jest.fn()


### PR DESCRIPTION
Initialization without configuration keeps short-lived processes alive until the timeout fires because the controller's timer remains referenced.

The initialization controller owns this timer. Marking it as unreferenced there preserves timeout behavior for active processes and avoids callers reaching into private state.