### PR TITLE
feat: support semantic version conditions

### DIFF
--- a/packages/core/src/evaluation/evaluateForSubject.ts
+++ b/packages/core/src/evaluation/evaluateForSubject.ts
@@ -4,7 +4,7 @@ import { type TimeStamp, timeStampNow } from '../time'
 import { TargetingKeyMissingError } from './errors'
 import { createEvaluationTimestampMetadata } from './evaluationMetadata'
 import { matchesShard } from './matchesShard'
-import { isValidRule, matchesRule, type Rule } from './rules'
+import { hasInvalidSemverComparand, isValidRule, matchesRule, type Rule } from './rules'
 import { type Flag, type Split, type VariantType, variantTypeToFlagValueType } from './ufc-v1'
 
 export function evaluateForSubject<T extends FlagValueType>(
@@ -157,15 +157,25 @@ function validateTypeMatch(expectedType: FlagValueType, variantType: VariantType
 }
 
 function isValidFlag(flag: Flag): boolean {
-  return (
-    Array.isArray(flag.allocations) &&
-    flag.allocations.every(
+  if (!Array.isArray(flag.allocations)) {
+    return false
+  }
+
+  if (
+    flag.allocations.some(
       (allocation) =>
-        Array.isArray(allocation.splits) &&
-        allocation.splits.every((split) => Array.isArray(split.shards)) &&
-        (allocation.rules === undefined ||
-          (Array.isArray(allocation.rules) && allocation.rules.every((rule) => isValidRule(rule))))
+        Array.isArray(allocation.rules) && allocation.rules.some((rule) => hasInvalidSemverComparand(rule))
     )
+  ) {
+    throw new Error('invalid semantic version comparand')
+  }
+
+  return flag.allocations.every(
+    (allocation) =>
+      Array.isArray(allocation.splits) &&
+      allocation.splits.every((split) => Array.isArray(split.shards)) &&
+      (allocation.rules === undefined ||
+        (Array.isArray(allocation.rules) && allocation.rules.every((rule) => isValidRule(rule))))
   )
 }
 

--- a/packages/core/src/evaluation/rules.ts
+++ b/packages/core/src/evaluation/rules.ts
@@ -1,4 +1,5 @@
 import type { EvaluationContext, EvaluationContextValue } from '@openfeature/core'
+import { compareSemver, parseSemver } from './semver'
 
 export type ConditionValueType = EvaluationContextValue | EvaluationContextValue[]
 
@@ -12,6 +13,12 @@ export enum OperatorType {
   ONE_OF = 'ONE_OF',
   NOT_ONE_OF = 'NOT_ONE_OF',
   IS_NULL = 'IS_NULL',
+  SEMVER_EQ = 'SEMVER_EQ',
+  SEMVER_NEQ = 'SEMVER_NEQ',
+  SEMVER_LT = 'SEMVER_LT',
+  SEMVER_LTE = 'SEMVER_LTE',
+  SEMVER_GT = 'SEMVER_GT',
+  SEMVER_GTE = 'SEMVER_GTE',
 }
 
 const supportedOperators = new Set<string>(Object.values(OperatorType))
@@ -54,6 +61,20 @@ type NullCondition = {
   value: boolean
 }
 
+type SemverOperator =
+  | OperatorType.SEMVER_EQ
+  | OperatorType.SEMVER_NEQ
+  | OperatorType.SEMVER_LT
+  | OperatorType.SEMVER_LTE
+  | OperatorType.SEMVER_GT
+  | OperatorType.SEMVER_GTE
+
+type SemverCondition = {
+  operator: SemverOperator
+  attribute: string
+  value: string
+}
+
 export type Condition =
   | MatchesCondition
   | NotMatchesCondition
@@ -61,6 +82,7 @@ export type Condition =
   | NotOneOfCondition
   | NumericCondition
   | NullCondition
+  | SemverCondition
 
 export interface Rule {
   conditions: Condition[]
@@ -74,6 +96,9 @@ export function isValidRule(rule: Rule): boolean {
   return rule.conditions.every((condition) => {
     if (!supportedOperators.has(condition.operator)) {
       return false
+    }
+    if (isSemverOperator(condition.operator)) {
+      return parseSemver(condition.value) !== null
     }
     if (condition.operator !== OperatorType.MATCHES && condition.operator !== OperatorType.NOT_MATCHES) {
       return true
@@ -132,9 +157,65 @@ function evaluateCondition(subjectAttributes: EvaluationContext, condition: Cond
         return isOneOf(value.toString(), condition.value)
       case OperatorType.NOT_ONE_OF:
         return isNotOneOf(value.toString(), condition.value)
+      case OperatorType.SEMVER_EQ:
+      case OperatorType.SEMVER_NEQ:
+      case OperatorType.SEMVER_LT:
+      case OperatorType.SEMVER_LTE:
+      case OperatorType.SEMVER_GT:
+      case OperatorType.SEMVER_GTE:
+        return evaluateSemverCondition(value, condition.value, condition.operator)
     }
   }
   return false
+}
+
+export function isSemverOperator(operator: string): operator is SemverOperator {
+  return (
+    operator === OperatorType.SEMVER_EQ ||
+    operator === OperatorType.SEMVER_NEQ ||
+    operator === OperatorType.SEMVER_LT ||
+    operator === OperatorType.SEMVER_LTE ||
+    operator === OperatorType.SEMVER_GT ||
+    operator === OperatorType.SEMVER_GTE
+  )
+}
+
+export function hasInvalidSemverComparand(rule: Rule): boolean {
+  return rule.conditions.some(
+    (condition) => isSemverOperator(condition.operator) && parseSemver(condition.value) === null
+  )
+}
+
+function evaluateSemverCondition(
+  attributeValue: EvaluationContextValue,
+  comparandValue: string,
+  operator: SemverOperator
+): boolean {
+  if (typeof attributeValue !== 'string') {
+    return false
+  }
+
+  const attribute = parseSemver(attributeValue)
+  const comparand = parseSemver(comparandValue)
+  if (!attribute || !comparand) {
+    return false
+  }
+
+  const ordering = compareSemver(attribute, comparand)
+  switch (operator) {
+    case OperatorType.SEMVER_EQ:
+      return ordering === 0
+    case OperatorType.SEMVER_NEQ:
+      return ordering !== 0
+    case OperatorType.SEMVER_LT:
+      return ordering < 0
+    case OperatorType.SEMVER_LTE:
+      return ordering <= 0
+    case OperatorType.SEMVER_GT:
+      return ordering > 0
+    case OperatorType.SEMVER_GTE:
+      return ordering >= 0
+  }
 }
 
 function compileRegex(pattern: string): RegExp {

--- a/packages/core/src/evaluation/semver.ts
+++ b/packages/core/src/evaluation/semver.ts
@@ -1,0 +1,231 @@
+const MAX_UINT64 = '18446744073709551615'
+
+/**
+ * The language-neutral SemVer representation used by the FFE evaluator.
+ * Build metadata is validated while parsing but is intentionally not retained,
+ * because it does not affect SemVer precedence.
+ */
+export interface ParsedSemver {
+  major: string
+  minor: string
+  patch: string
+  prerelease: string
+}
+
+/**
+ * Parse the SemVer subset.
+ * Core identifiers are limited to uint64; numeric prerelease identifiers may
+ * be arbitrarily large.
+ */
+export function parseSemver(version: unknown): ParsedSemver | null {
+  if (typeof version !== 'string') {
+    return null
+  }
+
+  const major = parseCoreIdentifier(version, 0)
+  if (!major || major.next >= version.length || version[major.next] !== '.') {
+    return null
+  }
+
+  const minor = parseCoreIdentifier(version, major.next + 1)
+  if (!minor || minor.next >= version.length || version[minor.next] !== '.') {
+    return null
+  }
+
+  const patch = parseCoreIdentifier(version, minor.next + 1)
+  if (!patch) {
+    return null
+  }
+
+  const parsed: ParsedSemver = {
+    major: major.value,
+    minor: minor.value,
+    patch: patch.value,
+    prerelease: '',
+  }
+
+  if (patch.next === version.length) {
+    return parsed
+  }
+
+  let remainder = version.slice(patch.next)
+  if (remainder.startsWith('-')) {
+    remainder = remainder.slice(1)
+    const buildStart = remainder.indexOf('+')
+    if (buildStart === -1) {
+      return isValidSemverIdentifiers(remainder, false) ? { ...parsed, prerelease: remainder } : null
+    }
+
+    const prerelease = remainder.slice(0, buildStart)
+    if (!isValidSemverIdentifiers(prerelease, false)) {
+      return null
+    }
+    parsed.prerelease = prerelease
+    remainder = remainder.slice(buildStart + 1)
+  } else if (remainder.startsWith('+')) {
+    remainder = remainder.slice(1)
+  } else {
+    return null
+  }
+
+  return isValidSemverIdentifiers(remainder, true) ? parsed : null
+}
+
+/** Compare SemVer precedence. Build metadata is intentionally ignored. */
+export function compareSemver(left: ParsedSemver, right: ParsedSemver): number {
+  for (const [leftValue, rightValue] of [
+    [left.major, right.major],
+    [left.minor, right.minor],
+    [left.patch, right.patch],
+  ]) {
+    const ordering = compareNumericStrings(leftValue, rightValue)
+    if (ordering !== 0) {
+      return ordering
+    }
+  }
+
+  return compareSemverPrerelease(left.prerelease, right.prerelease)
+}
+
+function parseCoreIdentifier(version: string, start: number): { value: string; next: number } | null {
+  if (start >= version.length || !isAsciiDigit(version.charCodeAt(start))) {
+    return null
+  }
+
+  if (version[start] === '0') {
+    return { value: '0', next: start + 1 }
+  }
+
+  let end = start
+  while (end < version.length && isAsciiDigit(version.charCodeAt(end))) {
+    end++
+  }
+
+  const value = version.slice(start, end)
+  if (value.length > MAX_UINT64.length || (value.length === MAX_UINT64.length && value > MAX_UINT64)) {
+    return null
+  }
+  return { value, next: end }
+}
+
+function isValidSemverIdentifiers(value: string, allowLeadingZeros: boolean): boolean {
+  let identifierStart = 0
+  let identifierNumeric = true
+
+  for (let i = 0; i <= value.length; i++) {
+    if (i === value.length || value[i] === '.') {
+      if (i === identifierStart) {
+        return false
+      }
+      if (!allowLeadingZeros && identifierNumeric && i - identifierStart > 1 && value[identifierStart] === '0') {
+        return false
+      }
+      identifierStart = i + 1
+      identifierNumeric = true
+      continue
+    }
+
+    const code = value.charCodeAt(i)
+    if (!isAsciiAlphanumeric(code) && value[i] !== '-') {
+      return false
+    }
+    if (!isAsciiDigit(code)) {
+      identifierNumeric = false
+    }
+  }
+
+  return true
+}
+
+function compareSemverPrerelease(left: string, right: string): number {
+  if (left === right) {
+    return 0
+  }
+  if (left === '') {
+    return 1
+  }
+  if (right === '') {
+    return -1
+  }
+
+  let leftRemaining = left
+  let rightRemaining = right
+  while (true) {
+    const [leftIdentifier, nextLeft] = nextSemverIdentifier(leftRemaining)
+    const [rightIdentifier, nextRight] = nextSemverIdentifier(rightRemaining)
+    const ordering = compareSemverIdentifier(leftIdentifier, rightIdentifier)
+    if (ordering !== 0) {
+      return ordering
+    }
+
+    if (nextLeft === '' || nextRight === '') {
+      if (nextLeft === '' && nextRight === '') {
+        return 0
+      }
+      return nextLeft === '' ? -1 : 1
+    }
+
+    leftRemaining = nextLeft.slice(1)
+    rightRemaining = nextRight.slice(1)
+  }
+}
+
+function nextSemverIdentifier(value: string): [string, string] {
+  const dot = value.indexOf('.')
+  return dot === -1 ? [value, ''] : [value.slice(0, dot), value.slice(dot)]
+}
+
+function compareSemverIdentifier(left: string, right: string): number {
+  const leftNumeric = isSemverNumericIdentifier(left)
+  const rightNumeric = isSemverNumericIdentifier(right)
+
+  if (leftNumeric && rightNumeric) {
+    return compareNumericStrings(left, right)
+  }
+  if (leftNumeric) {
+    return -1
+  }
+  if (rightNumeric) {
+    return 1
+  }
+  return compareAsciiStrings(left, right)
+}
+
+function isSemverNumericIdentifier(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    if (!isAsciiDigit(value.charCodeAt(i))) {
+      return false
+    }
+  }
+  return true
+}
+
+function compareNumericStrings(left: string, right: string): number {
+  if (left.length !== right.length) {
+    return left.length < right.length ? -1 : 1
+  }
+  return compareAsciiStrings(left, right)
+}
+
+function compareAsciiStrings(left: string, right: string): number {
+  const length = Math.min(left.length, right.length)
+  for (let i = 0; i < length; i++) {
+    const leftCode = left.charCodeAt(i)
+    const rightCode = right.charCodeAt(i)
+    if (leftCode !== rightCode) {
+      return leftCode < rightCode ? -1 : 1
+    }
+  }
+  if (left.length === right.length) {
+    return 0
+  }
+  return left.length < right.length ? -1 : 1
+}
+
+function isAsciiDigit(code: number): boolean {
+  return code >= 48 && code <= 57
+}
+
+function isAsciiAlphanumeric(code: number): boolean {
+  return isAsciiDigit(code) || (code >= 65 && code <= 90) || (code >= 97 && code <= 122)
+}

--- a/packages/core/test/evaluation/semver.spec.ts
+++ b/packages/core/test/evaluation/semver.spec.ts
@@ -99,6 +99,11 @@ describe('SemVer', () => {
     })
   })
 
+  it('orders core components above Number.MAX_SAFE_INTEGER without precision loss', () => {
+    expect(compareSemver(parse('9007199254740992.0.0'), parse('9007199254740991.0.0'))).toBeGreaterThan(0)
+    expect(compareSemver(parse('18446744073709551615.0.0'), parse('18446744073709551614.0.0'))).toBeGreaterThan(0)
+  })
+
   it('ignores build metadata', () => {
     expect(compareSemver(parse('1.0.0+build.1'), parse('1.0.0+build.2'))).toBe(0)
   })

--- a/packages/core/test/evaluation/semver.spec.ts
+++ b/packages/core/test/evaluation/semver.spec.ts
@@ -1,0 +1,193 @@
+import type { EvaluationContext } from '@openfeature/core'
+import { isValidRule, matchesRule, OperatorType, type Rule } from '../../src/evaluation/rules'
+import { compareSemver, type ParsedSemver, parseSemver } from '../../src/evaluation/semver'
+
+type SemverOperator =
+  | OperatorType.SEMVER_EQ
+  | OperatorType.SEMVER_NEQ
+  | OperatorType.SEMVER_LT
+  | OperatorType.SEMVER_LTE
+  | OperatorType.SEMVER_GT
+  | OperatorType.SEMVER_GTE
+
+function parse(version: string): ParsedSemver {
+  const parsed = parseSemver(version)
+  if (!parsed) {
+    throw new Error(`Expected valid SemVer: ${version}`)
+  }
+  return parsed
+}
+
+describe('SemVer', () => {
+  it.each([
+    '0.0.0',
+    '1.2.3-alpha.1',
+    '1.2.3+build.001',
+    '1.2.3-alpha-1+build.001',
+    '18446744073709551615.18446744073709551615.18446744073709551615',
+    '1.2.3-18446744073709551616',
+  ])('accepts %s', (version) => {
+    expect(parseSemver(version)).not.toBeNull()
+  })
+
+  it.each([
+    '',
+    '1',
+    '1.2',
+    '1.2.3.4',
+    'v1.2.3',
+    '01.2.3',
+    '1.02.3',
+    '1.2.03',
+    '18446744073709551616.0.0',
+    '1.2.3-',
+    '1.2.3+',
+    '1.2.3-alpha..1',
+    '1.2.3+build..1',
+    '1.2.3-01',
+    '1.2.3-alpha_1',
+    '1.2.3-alpha+build+other',
+    '1.2.3-α',
+    ' 1.2.3',
+    '1.2.3 ',
+  ])('rejects %s', (version) => {
+    expect(parseSemver(version)).toBeNull()
+  })
+
+  it('orders prerelease versions according to SemVer precedence', () => {
+    const ordered = [
+      '1.0.0-alpha',
+      '1.0.0-alpha.1',
+      '1.0.0-alpha.beta',
+      '1.0.0-beta',
+      '1.0.0-beta.2',
+      '1.0.0-beta.11',
+      '1.0.0-rc.1',
+      '1.0.0',
+      '1.0.1',
+      '1.1.0',
+      '2.0.0',
+    ]
+
+    for (let i = 0; i < ordered.length; i++) {
+      for (let j = 0; j < ordered.length; j++) {
+        const ordering = compareSemver(parse(ordered[i]), parse(ordered[j]))
+        expect(Math.sign(ordering)).toBe(Math.sign(i - j))
+      }
+    }
+  })
+
+  it('compares arbitrarily large numeric prerelease identifiers', () => {
+    expect(compareSemver(parse('1.0.0-99999999999999999999'), parse('1.0.0-100000000000000000000'))).toBeLessThan(0)
+  })
+
+  it('parses the core and prerelease fields while discarding build metadata', () => {
+    expect(parseSemver('1.2.3-alpha.1+build.001')).toEqual({
+      major: '1',
+      minor: '2',
+      patch: '3',
+      prerelease: 'alpha.1',
+    })
+  })
+
+  it('accepts the maximum uint64 core components', () => {
+    expect(parseSemver('18446744073709551615.18446744073709551615.18446744073709551615')).toEqual({
+      major: '18446744073709551615',
+      minor: '18446744073709551615',
+      patch: '18446744073709551615',
+      prerelease: '',
+    })
+  })
+
+  it('ignores build metadata', () => {
+    expect(compareSemver(parse('1.0.0+build.1'), parse('1.0.0+build.2'))).toBe(0)
+  })
+
+  describe('condition evaluation', () => {
+    function matchesSemver(operator: SemverOperator, attribute: unknown, comparand: unknown): boolean {
+      return matchesRule(
+        {
+          conditions: [
+            {
+              operator,
+              attribute: 'version',
+              value: comparand as string,
+            },
+          ],
+        },
+        { version: attribute } as EvaluationContext
+      )
+    }
+
+    it.each([
+      ['equal', OperatorType.SEMVER_EQ, '1.2.3', '1.2.3', true],
+      ['equal mismatch', OperatorType.SEMVER_EQ, '1.2.4', '1.2.3', false],
+      ['not equal', OperatorType.SEMVER_NEQ, '1.2.4', '1.2.3', true],
+      ['not equal mismatch', OperatorType.SEMVER_NEQ, '1.2.3', '1.2.3', false],
+      ['less than', OperatorType.SEMVER_LT, '1.9.9', '2.0.0', true],
+      ['less than mismatch', OperatorType.SEMVER_LT, '2.0.0', '2.0.0', false],
+      ['less than or equal', OperatorType.SEMVER_LTE, '2.0.0', '2.0.0', true],
+      ['less than or equal mismatch', OperatorType.SEMVER_LTE, '2.0.1', '2.0.0', false],
+      ['greater than', OperatorType.SEMVER_GT, '1.0.1', '1.0.0', true],
+      ['greater than mismatch', OperatorType.SEMVER_GT, '1.0.0', '1.0.0', false],
+      ['greater than or equal', OperatorType.SEMVER_GTE, '1.0.0', '1.0.0', true],
+      ['greater than or equal mismatch', OperatorType.SEMVER_GTE, '0.9.9', '1.0.0', false],
+    ] as const)('%s', (_name, operator, attribute, comparand, expected) => {
+      expect(matchesSemver(operator, attribute, comparand)).toBe(expected)
+    })
+
+    it.each([
+      [OperatorType.SEMVER_EQ, true],
+      [OperatorType.SEMVER_NEQ, false],
+      [OperatorType.SEMVER_LT, false],
+      [OperatorType.SEMVER_LTE, true],
+      [OperatorType.SEMVER_GT, false],
+      [OperatorType.SEMVER_GTE, true],
+    ] as const)('ignores build metadata for %s', (operator, expected) => {
+      expect(matchesSemver(operator, '4.0.0+build.42', '4.0.0')).toBe(expected)
+    })
+
+    it('treats different build metadata as equal precedence', () => {
+      expect(matchesSemver(OperatorType.SEMVER_EQ, '1.0.0+linux', '1.0.0+darwin')).toBe(true)
+      expect(matchesSemver(OperatorType.SEMVER_EQ, '4.0.0+exp.sha.5114f85', '4.0.0')).toBe(true)
+    })
+
+    it.each(['not-a-version', '1.2', 'v1.2.3', '18446744073709551616.0.0'])(
+      'does not match an invalid attribute: %s',
+      (attribute) => {
+        expect(matchesSemver(OperatorType.SEMVER_NEQ, attribute, '1.0.0')).toBe(false)
+      }
+    )
+
+    it('does not match a missing or non-string attribute', () => {
+      expect(
+        matchesRule(
+          {
+            conditions: [{ operator: OperatorType.SEMVER_EQ, attribute: 'version', value: '1.0.0' }],
+          },
+          {} as EvaluationContext
+        )
+      ).toBe(false)
+      expect(matchesSemver(OperatorType.SEMVER_EQ, 1.2, '1.2.0')).toBe(false)
+    })
+
+    it('does not match an invalid or non-string comparand', () => {
+      expect(matchesSemver(OperatorType.SEMVER_EQ, '1.2.3', 'not-a-version')).toBe(false)
+      expect(matchesSemver(OperatorType.SEMVER_EQ, '1.2.3', 1.2)).toBe(false)
+    })
+
+    it('rejects invalid configured SemVer comparands during rule validation', () => {
+      const rule: Rule = {
+        conditions: [{ operator: OperatorType.SEMVER_EQ, attribute: 'version', value: 'not-a-version' }],
+      }
+      expect(isValidRule(rule)).toBe(false)
+    })
+
+    it('returns false for unsupported operators', () => {
+      const rule = {
+        conditions: [{ operator: 'UNKNOWN', attribute: 'version', value: '1.0.0' }],
+      } as unknown as Rule
+      expect(matchesRule(rule, { version: '1.0.0' } as EvaluationContext)).toBe(false)
+    })
+  })
+})

--- a/packages/node-server/index.d.ts
+++ b/packages/node-server/index.d.ts
@@ -438,7 +438,13 @@ declare enum OperatorType {
 	LT = "LT",
 	ONE_OF = "ONE_OF",
 	NOT_ONE_OF = "NOT_ONE_OF",
-	IS_NULL = "IS_NULL"
+	IS_NULL = "IS_NULL",
+	SEMVER_EQ = "SEMVER_EQ",
+	SEMVER_NEQ = "SEMVER_NEQ",
+	SEMVER_LT = "SEMVER_LT",
+	SEMVER_LTE = "SEMVER_LTE",
+	SEMVER_GT = "SEMVER_GT",
+	SEMVER_GTE = "SEMVER_GTE"
 }
 type NumericOperator = OperatorType.GTE | OperatorType.GT | OperatorType.LTE | OperatorType.LT;
 type MatchesCondition = {
@@ -471,7 +477,13 @@ type NullCondition = {
 	attribute: string;
 	value: boolean;
 };
-type Condition = MatchesCondition | NotMatchesCondition | OneOfCondition | NotOneOfCondition | NumericCondition | NullCondition;
+type SemverOperator = OperatorType.SEMVER_EQ | OperatorType.SEMVER_NEQ | OperatorType.SEMVER_LT | OperatorType.SEMVER_LTE | OperatorType.SEMVER_GT | OperatorType.SEMVER_GTE;
+type SemverCondition = {
+	operator: SemverOperator;
+	attribute: string;
+	value: string;
+};
+type Condition = MatchesCondition | NotMatchesCondition | OneOfCondition | NotOneOfCondition | NumericCondition | NullCondition | SemverCondition;
 interface Rule {
 	conditions: Condition[];
 }

--- a/packages/node-server/test/ffe-system.spec.ts
+++ b/packages/node-server/test/ffe-system.spec.ts
@@ -1,0 +1,88 @@
+import type { Channel } from 'node:diagnostics_channel'
+import fs from 'node:fs'
+import path from 'node:path'
+import type { ExposureEvent } from '@datadog/flagging-core'
+import type { EvaluationContext, FlagValue, JsonValue, Logger, ResolutionDetails } from '@openfeature/core'
+import type { UniversalFlagConfigurationV1, VariantType } from '../src/configuration/ufc-v1'
+import { DatadogNodeServerProvider } from '../src/provider'
+
+type SystemTestCase = {
+  flag: string
+  variationType: VariantType
+  defaultValue: FlagValue
+  targetingKey: string | null
+  attributes: Record<string, unknown>
+  result: {
+    value: FlagValue
+    reason: string
+  }
+}
+
+const fixtureDirectory = path.join(__dirname, '../../core/test/ffe-system-test-data')
+const configuration = JSON.parse(
+  fs.readFileSync(path.join(fixtureDirectory, 'ufc-config.json'), 'utf8')
+) as UniversalFlagConfigurationV1
+
+const exposureChannel = {
+  hasSubscribers: false,
+  publish: jest.fn(),
+} as unknown as jest.Mocked<Channel<ExposureEvent>>
+
+const logger: Logger = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+}
+
+function getTestCaseFileNames(): string[] {
+  const fixtureFiles = fs
+    .readdirSync(path.join(fixtureDirectory, 'evaluation-cases'))
+    .filter((fileName) => fileName.endsWith('.json'))
+    .sort()
+  if (fixtureFiles.length === 0) {
+    throw new Error('FFE fixture submodule is missing or empty')
+  }
+  return fixtureFiles
+}
+
+function getTestCases(testCaseFileName: string): SystemTestCase[] {
+  return JSON.parse(
+    fs.readFileSync(path.join(fixtureDirectory, 'evaluation-cases', testCaseFileName), 'utf8')
+  ) as SystemTestCase[]
+}
+
+async function evaluateTestCase(testCase: SystemTestCase): Promise<ResolutionDetails<FlagValue>> {
+  const provider = new DatadogNodeServerProvider({ exposureChannel })
+  provider.setConfiguration(configuration)
+
+  const context = {
+    ...(testCase.targetingKey === null ? {} : { targetingKey: testCase.targetingKey }),
+    ...testCase.attributes,
+  } as EvaluationContext
+
+  switch (testCase.variationType) {
+    case 'BOOLEAN':
+      return provider.resolveBooleanEvaluation(testCase.flag, testCase.defaultValue as boolean, context, logger)
+    case 'STRING':
+      return provider.resolveStringEvaluation(testCase.flag, testCase.defaultValue as string, context, logger)
+    case 'INTEGER':
+    case 'NUMERIC':
+      return provider.resolveNumberEvaluation(testCase.flag, testCase.defaultValue as number, context, logger)
+    case 'JSON':
+      return provider.resolveObjectEvaluation(testCase.flag, testCase.defaultValue as JsonValue, context, logger)
+  }
+}
+
+describe('FFE system tests through DatadogNodeServerProvider', () => {
+  describe.each(getTestCaseFileNames())('should evaluate for %s', (testCaseFileName) => {
+    const testCases = getTestCases(testCaseFileName)
+
+    it.each(testCases)('with context $targetingKey and flag $flag', async (testCase) => {
+      const details = await evaluateTestCase(testCase)
+
+      expect(details.value).toEqual(testCase.result.value)
+      expect(details.reason).toEqual(testCase.result.reason)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add SEMVER evaluation to `@datadog/flagging-core`.
- Support `SEMVER_EQ`, `SEMVER_NEQ`, `SEMVER_LT`, `SEMVER_LTE`, `SEMVER_GT`, and `SEMVER_GTE`.
- Run all shared FFE evaluation cases through `DatadogNodeServerProvider`.
- Add focused core SemVer unit coverage.
- Pin `ffe-system-test-data` to `aaa97e4`, which has the SEMVER system tests.

## Why uint64-safe string comparison

The evaluator keeps SemVer core components as decimal strings instead of converting them to JavaScript `Number` values.

- **Compatibility:** The FFE SemVer behavior is shared across SDKs. The Go/Rust-compatible implementation accepts `uint64`-bounded core components, including values above `Number.MAX_SAFE_INTEGER`, so narrowing JavaScript to `Number.MAX_SAFE_INTEGER` would create cross-SDK differences.
- **Performance:** Length-plus-digit string comparison avoids `Number` parsing on every evaluation and is faster than converting the component strings to numbers at comparison time. It also avoids precision loss for large valid versions.
