### PR TITLE
test(browser): execute packed package in Chromium

### DIFF
--- a/scripts/test-package-install.sh
+++ b/scripts/test-package-install.sh
@@ -32,7 +32,7 @@ cd "$REPO_ROOT/packages/browser"
 
 # Save original package.json and yarn.lock
 cp package.json package.json.backup
-
+cp "$REPO_ROOT/yarn.lock" "$REPO_ROOT/yarn.lock.backup"
 
 # Install the tarball temporarily
 yarn add "@datadog/flagging-core@file:$TEST_APP_DIR/core.tgz" --silent
@@ -45,6 +45,8 @@ yarn pack --filename "$TEST_APP_DIR/browser.tgz" > /dev/null 2>&1
 echo "Restoring browser package..."
 rm package.json
 mv package.json.backup package.json
+rm "$REPO_ROOT/yarn.lock"
+mv "$REPO_ROOT/yarn.lock.backup" "$REPO_ROOT/yarn.lock"
 
 cd "$REPO_ROOT"
 
@@ -67,8 +69,19 @@ yarn add @datadog/openfeature-browser@file:./browser.tgz --silent
 echo "Building test app..."
 yarn build
 
+# Execute the built application in a real browser runtime
+echo "Installing Chromium..."
+if [[ "${CI:-}" == "true" ]]; then
+  yarn playwright install --with-deps --only-shell chromium
+else
+  yarn playwright install --only-shell chromium
+fi
+
+echo "Running browser smoke tests..."
+yarn test:browser
+
 echo ""
-echo "✓ All tests passed! Package can be installed and the app builds successfully."
+echo "✓ All tests passed! Package can be installed and executed in Chromium."
 echo ""
 echo "To run the test app locally:"
 echo "  cd test-app"

--- a/scripts/test-package-install.sh
+++ b/scripts/test-package-install.sh
@@ -5,6 +5,21 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Get the repo root (parent of scripts/)
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BROWSER_PACKAGE_JSON="$REPO_ROOT/packages/browser/package.json"
+BROWSER_PACKAGE_JSON_BACKUP="$BROWSER_PACKAGE_JSON.backup"
+ROOT_YARN_LOCK="$REPO_ROOT/yarn.lock"
+ROOT_YARN_LOCK_BACKUP="$ROOT_YARN_LOCK.backup"
+
+restore_package_files() {
+  if [[ -f "$BROWSER_PACKAGE_JSON_BACKUP" ]]; then
+    mv -f "$BROWSER_PACKAGE_JSON_BACKUP" "$BROWSER_PACKAGE_JSON"
+  fi
+  if [[ -f "$ROOT_YARN_LOCK_BACKUP" ]]; then
+    mv -f "$ROOT_YARN_LOCK_BACKUP" "$ROOT_YARN_LOCK"
+  fi
+}
+
+trap restore_package_files EXIT
 
 echo "Testing @datadog/openfeature-browser package installation..."
 echo "Repository root: $REPO_ROOT"
@@ -31,8 +46,8 @@ echo "Installing packed core into browser package..."
 cd "$REPO_ROOT/packages/browser"
 
 # Save original package.json and yarn.lock
-cp package.json package.json.backup
-cp "$REPO_ROOT/yarn.lock" "$REPO_ROOT/yarn.lock.backup"
+cp "$BROWSER_PACKAGE_JSON" "$BROWSER_PACKAGE_JSON_BACKUP"
+cp "$ROOT_YARN_LOCK" "$ROOT_YARN_LOCK_BACKUP"
 
 # Install the tarball temporarily
 yarn add "@datadog/flagging-core@file:$TEST_APP_DIR/core.tgz" --silent
@@ -41,12 +56,10 @@ yarn add "@datadog/flagging-core@file:$TEST_APP_DIR/core.tgz" --silent
 echo "Packing @datadog/openfeature-browser..."
 yarn pack --filename "$TEST_APP_DIR/browser.tgz" > /dev/null 2>&1
 
-# Restore browser package to original state using git
+# Restore browser package to original state
 echo "Restoring browser package..."
-rm package.json
-mv package.json.backup package.json
-rm "$REPO_ROOT/yarn.lock"
-mv "$REPO_ROOT/yarn.lock.backup" "$REPO_ROOT/yarn.lock"
+restore_package_files
+trap - EXIT
 
 cd "$REPO_ROOT"
 

--- a/test-app/index.html
+++ b/test-app/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Datadog OpenFeature full browser smoke test</title>
+    <title>Datadog OpenFeature protobuf browser smoke test</title>
   </head>
   <body>
     <pre id="app"></pre>
-    <script type="module" src="/src/main.ts"></script>
+    <script type="module" src="/src/protobuf.ts"></script>
   </body>
 </html>

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:browser": "playwright test"
   },
   "dependencies": {
     "@datadog/flagging-core": "file:./core.tgz",
@@ -15,6 +16,7 @@
     "@openfeature/web-sdk": "^1.7.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "typescript": "^5.9.3",
     "vite": "^8.1.3"
   }

--- a/test-app/playwright.config.ts
+++ b/test-app/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests',
+  outputDir: './node_modules/.cache/playwright-test',
+  reporter: 'line',
+  workers: 1,
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+  },
+  webServer: {
+    command: 'yarn preview --host 127.0.0.1 --port 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: false,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/test-app/precomputed.html
+++ b/test-app/precomputed.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Datadog OpenFeature full browser smoke test</title>
+    <title>Datadog OpenFeature precomputed browser smoke test</title>
   </head>
   <body>
     <pre id="app"></pre>
-    <script type="module" src="/src/main.ts"></script>
+    <script type="module" src="/src/precomputed.ts"></script>
   </body>
 </html>

--- a/test-app/src/main.ts
+++ b/test-app/src/main.ts
@@ -1,45 +1,55 @@
-import { DatadogProvider } from '@datadog/openfeature-browser'
-import { OpenFeature } from '@openfeature/web-sdk'
+import { evaluateRulesBasedConfiguration, matchesRule, OperatorType } from '@datadog/flagging-core'
+import { configurationFromString, configurationToString } from '@datadog/openfeature-browser'
+import { assert, reportSuccess } from './smoke'
 
-// Initialize the Datadog provider
-const provider = new DatadogProvider({
-  applicationId: 'test-app-id',
-  clientToken: 'test-token',
-  site: 'datadoghq.com',
-  service: 'test-service',
+const rulesResponse =
+  'EgRwcm9kGigKDGJyb3dzZXItZmxhZxIYEAQaAigBIhAKCmFsbG9jYXRpb24iAiADGigKDGludGVnZXItZmxhZxIYEAIaAhgqIhAKCmFsbG9jYXRpb24iAiADKgJvbg=='
+const configuration = configurationFromString(JSON.stringify({ version: 1, rules: { response: rulesResponse } }))
+
+assert(configuration.rules, 'rules configuration was not parsed')
+
+const context = { targetingKey: 'browser-user' }
+const booleanDetails = evaluateRulesBasedConfiguration(
+  configuration.rules.response,
+  'boolean',
+  'browser-flag',
+  false,
+  context,
+  console
+)
+const integerDetails = evaluateRulesBasedConfiguration(
+  configuration.rules.response,
+  'number',
+  'integer-flag',
+  0,
+  context,
+  console
+)
+const restored = configurationFromString(configurationToString(configuration))
+const sha256Matched = matchesRule(
+  {
+    conditions: [
+      {
+        attribute: 'name',
+        operator: OperatorType.ONE_OF_SHA256,
+        value: {
+          salt: [1, 2],
+          hashes: ['c0e551d80aa1e2cb1eaf5be7edbb04e51eb1823e562e2ce5dfeda0ecba76c744'],
+        },
+      },
+    ],
+  },
+  { name: 'hello' }
+)
+
+assert(booleanDetails.value === true, 'boolean rule evaluation returned the wrong value')
+assert(integerDetails.value === 42, 'integer rule evaluation returned the wrong value')
+assert(restored.rules?.response.flags['browser-flag'], 'rules configuration did not survive a round trip')
+assert(sha256Matched, 'SHA-256 condition did not match')
+
+reportSuccess({
+  entrypoint: 'full',
+  booleanValue: booleanDetails.value,
+  integerValue: integerDetails.value,
+  sha256Matched,
 })
-
-// Set the provider
-OpenFeature.setProvider(provider)
-
-// Get a client
-const client = OpenFeature.getClient()
-
-// Evaluate a flag using getBooleanDetails to get full evaluation details
-const details = client.getBooleanDetails('test-flag', false)
-
-console.log('✓ Successfully imported and initialized @datadog/openfeature-browser')
-console.log('Flag evaluation details:', details)
-
-// Format the details for display
-const detailsJson = JSON.stringify(details, null, 2)
-
-// Update the DOM to show success
-document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-  <div>
-    <h1>DataDog OpenFeature Browser Test App</h1>
-    <p class="success">✓ Successfully imported and initialized @datadog/openfeature-browser</p>
-
-    <div class="details">
-      <h2>Flag Evaluation Details</h2>
-      <p><strong>Flag Key:</strong> ${details.flagKey}</p>
-      <p><strong>Value:</strong> ${details.value}</p>
-      <p><strong>Reason:</strong> ${details.reason}</p>
-      <p><strong>Variant:</strong> ${details.variant || 'N/A'}</p>
-      <p><strong>Error Code:</strong> ${details.errorCode || 'N/A'}</p>
-
-      <h3>Full Details (JSON):</h3>
-      <pre>${detailsJson}</pre>
-    </div>
-  </div>
-`

--- a/test-app/src/precomputed.ts
+++ b/test-app/src/precomputed.ts
@@ -1,0 +1,39 @@
+import { configurationFromString, configurationToString } from '@datadog/openfeature-browser/precomputed'
+import { assert, reportSuccess } from './smoke'
+
+const response = {
+  data: {
+    attributes: {
+      createdAt: '2026-07-06T23:01:56.822Z',
+      flags: {
+        'precomputed-flag': {
+          allocationKey: 'allocation',
+          variationKey: 'on',
+          variationType: 'BOOLEAN',
+          variationValue: true,
+          reason: 'STATIC',
+          doLog: true,
+        },
+      },
+    },
+  },
+}
+const configuration = configurationFromString(
+  JSON.stringify({
+    version: 1,
+    precomputed: { response: JSON.stringify(response) },
+    rules: { response: 'ignored by the precomputed entrypoint' },
+  })
+)
+const roundTrip = JSON.parse(configurationToString(configuration)) as Record<string, unknown>
+const flag = configuration.precomputed?.response.data.attributes.flags['precomputed-flag']
+
+assert(flag?.variationValue === true, 'precomputed flag was not parsed')
+assert(configuration.rules === undefined, 'precomputed entrypoint parsed rules')
+assert(roundTrip.rules === undefined, 'precomputed entrypoint serialized rules')
+
+reportSuccess({
+  entrypoint: 'precomputed',
+  booleanValue: flag.variationValue,
+  rulesExcluded: true,
+})

--- a/test-app/src/precomputed.ts
+++ b/test-app/src/precomputed.ts
@@ -25,15 +25,19 @@ const configuration = configurationFromString(
     rules: { response: 'ignored by the precomputed entrypoint' },
   })
 )
-const roundTrip = JSON.parse(configurationToString(configuration)) as Record<string, unknown>
+const serialized = configurationToString(configuration)
+const roundTripWire = JSON.parse(serialized) as Record<string, unknown>
+const restored = configurationFromString(serialized)
 const flag = configuration.precomputed?.response.data.attributes.flags['precomputed-flag']
+const restoredFlag = restored.precomputed?.response.data.attributes.flags['precomputed-flag']
 
 assert(flag?.variationValue === true, 'precomputed flag was not parsed')
 assert(configuration.rules === undefined, 'precomputed entrypoint parsed rules')
-assert(roundTrip.rules === undefined, 'precomputed entrypoint serialized rules')
+assert(roundTripWire.rules === undefined, 'precomputed entrypoint serialized rules')
+assert(restoredFlag?.variationValue === true, 'precomputed flag did not survive a round trip')
 
 reportSuccess({
   entrypoint: 'precomputed',
-  booleanValue: flag.variationValue,
+  booleanValue: restoredFlag.variationValue,
   rulesExcluded: true,
 })

--- a/test-app/src/protobuf.ts
+++ b/test-app/src/protobuf.ts
@@ -1,11 +1,32 @@
 import { evaluateRulesBasedConfiguration, matchesRule, OperatorType } from '@datadog/flagging-core'
-import { configurationFromString, configurationToString } from '@datadog/openfeature-browser'
+import { configurationFromString, configurationToString, DatadogProvider } from '@datadog/openfeature-browser'
 import { assert, reportSuccess } from './smoke'
 
 const protobufRulesResponse =
   'EgRwcm9kGigKDGJyb3dzZXItZmxhZxIYEAQaAigBIhAKCmFsbG9jYXRpb24iAiADGigKDGludGVnZXItZmxhZxIYEAIaAhgqIhAKCmFsbG9jYXRpb24iAiADKgJvbg=='
+const precomputedResponse = {
+  data: {
+    attributes: {
+      createdAt: '2026-07-06T23:01:56.822Z',
+      flags: {
+        'provider-flag': {
+          allocationKey: 'allocation',
+          variationKey: 'on',
+          variationType: 'BOOLEAN',
+          variationValue: true,
+          reason: 'STATIC',
+          doLog: false,
+        },
+      },
+    },
+  },
+}
 const configuration = configurationFromString(
-  JSON.stringify({ version: 1, rules: { response: protobufRulesResponse } })
+  JSON.stringify({
+    version: 1,
+    precomputed: { response: JSON.stringify(precomputedResponse) },
+    rules: { response: protobufRulesResponse },
+  })
 )
 
 assert(configuration.rules, 'protobuf rules configuration was not decoded')
@@ -31,6 +52,16 @@ const integerDetails = evaluateRulesBasedConfiguration(
   context,
   console
 )
+const provider = new DatadogProvider({
+  clientToken: 'test-token',
+  site: 'datadoghq.com',
+  env: 'test',
+  enableExposureLogging: false,
+  enableFlagEvaluationTracking: false,
+  enableRumFeatureFlagTracking: false,
+  initialFlagsConfiguration: configuration,
+})
+const providerDetails = provider.resolveBooleanEvaluation('provider-flag', false, context, console)
 const restored = configurationFromString(configurationToString(configuration))
 const sha256Matched = matchesRule(
   {
@@ -50,6 +81,7 @@ const sha256Matched = matchesRule(
 
 assert(booleanDetails.value === true, 'protobuf boolean evaluation returned the wrong value')
 assert(integerDetails.value === 42, 'protobuf int64 evaluation returned the wrong value')
+assert(providerDetails.value === true, 'DatadogProvider did not evaluate the decoded configuration')
 assert(
   restored.rules?.response.$typeName === 'datadog.ffe.flagging.ufc.v1.FlagsConfiguration',
   'protobuf rules configuration did not survive a round trip'
@@ -61,5 +93,6 @@ reportSuccess({
   protobufTypeName: configuration.rules.response.$typeName,
   booleanValue: booleanDetails.value,
   integerValue: integerDetails.value,
+  providerValue: providerDetails.value,
   sha256Matched,
 })

--- a/test-app/src/protobuf.ts
+++ b/test-app/src/protobuf.ts
@@ -2,11 +2,17 @@ import { evaluateRulesBasedConfiguration, matchesRule, OperatorType } from '@dat
 import { configurationFromString, configurationToString } from '@datadog/openfeature-browser'
 import { assert, reportSuccess } from './smoke'
 
-const rulesResponse =
+const protobufRulesResponse =
   'EgRwcm9kGigKDGJyb3dzZXItZmxhZxIYEAQaAigBIhAKCmFsbG9jYXRpb24iAiADGigKDGludGVnZXItZmxhZxIYEAIaAhgqIhAKCmFsbG9jYXRpb24iAiADKgJvbg=='
-const configuration = configurationFromString(JSON.stringify({ version: 1, rules: { response: rulesResponse } }))
+const configuration = configurationFromString(
+  JSON.stringify({ version: 1, rules: { response: protobufRulesResponse } })
+)
 
-assert(configuration.rules, 'rules configuration was not parsed')
+assert(configuration.rules, 'protobuf rules configuration was not decoded')
+assert(
+  configuration.rules.response.$typeName === 'datadog.ffe.flagging.ufc.v1.FlagsConfiguration',
+  'rules response is not a generated protobuf message'
+)
 
 const context = { targetingKey: 'browser-user' }
 const booleanDetails = evaluateRulesBasedConfiguration(
@@ -42,13 +48,17 @@ const sha256Matched = matchesRule(
   { name: 'hello' }
 )
 
-assert(booleanDetails.value === true, 'boolean rule evaluation returned the wrong value')
-assert(integerDetails.value === 42, 'integer rule evaluation returned the wrong value')
-assert(restored.rules?.response.flags['browser-flag'], 'rules configuration did not survive a round trip')
+assert(booleanDetails.value === true, 'protobuf boolean evaluation returned the wrong value')
+assert(integerDetails.value === 42, 'protobuf int64 evaluation returned the wrong value')
+assert(
+  restored.rules?.response.$typeName === 'datadog.ffe.flagging.ufc.v1.FlagsConfiguration',
+  'protobuf rules configuration did not survive a round trip'
+)
 assert(sha256Matched, 'SHA-256 condition did not match')
 
 reportSuccess({
-  entrypoint: 'full',
+  entrypoint: 'protobuf',
+  protobufTypeName: configuration.rules.response.$typeName,
   booleanValue: booleanDetails.value,
   integerValue: integerDetails.value,
   sha256Matched,

--- a/test-app/src/smoke.ts
+++ b/test-app/src/smoke.ts
@@ -1,0 +1,11 @@
+export function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message)
+}
+
+export function reportSuccess(result: Record<string, unknown>): void {
+  const global = globalThis as typeof globalThis & { __OPENFEATURE_SMOKE_RESULT__?: Record<string, unknown> }
+  global.__OPENFEATURE_SMOKE_RESULT__ = result
+
+  const app = document.querySelector<HTMLDivElement>('#app')
+  if (app) app.textContent = JSON.stringify(result, null, 2)
+}

--- a/test-app/tests/smoke.spec.ts
+++ b/test-app/tests/smoke.spec.ts
@@ -32,6 +32,7 @@ test('decodes and evaluates packed protobuf rules in Chromium', async ({ page })
     protobufTypeName: 'datadog.ffe.flagging.ufc.v1.FlagsConfiguration',
     booleanValue: true,
     integerValue: 42,
+    providerValue: true,
     sha256Matched: true,
   })
 })
@@ -49,6 +50,7 @@ test('decodes protobuf without native text or bigint globals', async ({ page }) 
   expect(result.protobufTypeName).toBe('datadog.ffe.flagging.ufc.v1.FlagsConfiguration')
   expect(result.booleanValue).toBe(true)
   expect(result.integerValue).toBe(42)
+  expect(result.providerValue).toBe(true)
 })
 
 test('executes the packed precomputed entrypoint in Chromium', async ({ page }) => {

--- a/test-app/tests/smoke.spec.ts
+++ b/test-app/tests/smoke.spec.ts
@@ -1,0 +1,60 @@
+import { expect, type Page, test } from '@playwright/test'
+
+type SmokeResult = Record<string, unknown>
+
+async function runSmoke(page: Page, path: string): Promise<SmokeResult> {
+  const runtimeErrors: string[] = []
+  page.on('console', (message) => {
+    if (message.type() === 'error') runtimeErrors.push(`console.error: ${message.text()}`)
+  })
+  page.on('pageerror', (error) => runtimeErrors.push(`page error: ${error.message}`))
+
+  await page.goto(path)
+
+  expect(runtimeErrors).toEqual([])
+  const result = await page.evaluate(
+    () =>
+      (
+        globalThis as typeof globalThis & {
+          __OPENFEATURE_SMOKE_RESULT__?: SmokeResult
+        }
+      ).__OPENFEATURE_SMOKE_RESULT__
+  )
+  expect(result).toBeDefined()
+  return result!
+}
+
+test('executes the packed full entrypoint in Chromium', async ({ page }) => {
+  const result = await runSmoke(page, '/')
+
+  expect(result).toEqual({
+    entrypoint: 'full',
+    booleanValue: true,
+    integerValue: 42,
+    sha256Matched: true,
+  })
+})
+
+test('executes the packed full entrypoint without native text or bigint globals', async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.assign(globalThis, {
+      BigInt: undefined,
+      TextDecoder: undefined,
+      TextEncoder: undefined,
+    })
+  })
+
+  const result = await runSmoke(page, '/')
+  expect(result.booleanValue).toBe(true)
+  expect(result.integerValue).toBe(42)
+})
+
+test('executes the packed precomputed entrypoint in Chromium', async ({ page }) => {
+  const result = await runSmoke(page, '/precomputed.html')
+
+  expect(result).toEqual({
+    entrypoint: 'precomputed',
+    booleanValue: true,
+    rulesExcluded: true,
+  })
+})

--- a/test-app/tests/smoke.spec.ts
+++ b/test-app/tests/smoke.spec.ts
@@ -24,18 +24,19 @@ async function runSmoke(page: Page, path: string): Promise<SmokeResult> {
   return result!
 }
 
-test('executes the packed full entrypoint in Chromium', async ({ page }) => {
+test('decodes and evaluates packed protobuf rules in Chromium', async ({ page }) => {
   const result = await runSmoke(page, '/')
 
   expect(result).toEqual({
-    entrypoint: 'full',
+    entrypoint: 'protobuf',
+    protobufTypeName: 'datadog.ffe.flagging.ufc.v1.FlagsConfiguration',
     booleanValue: true,
     integerValue: 42,
     sha256Matched: true,
   })
 })
 
-test('executes the packed full entrypoint without native text or bigint globals', async ({ page }) => {
+test('decodes protobuf without native text or bigint globals', async ({ page }) => {
   await page.addInitScript(() => {
     Object.assign(globalThis, {
       BigInt: undefined,
@@ -45,6 +46,7 @@ test('executes the packed full entrypoint without native text or bigint globals'
   })
 
   const result = await runSmoke(page, '/')
+  expect(result.protobufTypeName).toBe('datadog.ffe.flagging.ufc.v1.FlagsConfiguration')
   expect(result.booleanValue).toBe(true)
   expect(result.integerValue).toBe(42)
 })

--- a/test-app/vite.config.ts
+++ b/test-app/vite.config.ts
@@ -1,7 +1,14 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
   build: {
     target: 'es2015',
+    rollupOptions: {
+      input: {
+        full: fileURLToPath(new URL('./index.html', import.meta.url)),
+        precomputed: fileURLToPath(new URL('./precomputed.html', import.meta.url)),
+      },
+    },
   },
 })

--- a/test-app/vite.config.ts
+++ b/test-app/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     target: 'es2015',
     rollupOptions: {
       input: {
-        full: fileURLToPath(new URL('./index.html', import.meta.url)),
+        protobuf: fileURLToPath(new URL('./index.html', import.meta.url)),
         precomputed: fileURLToPath(new URL('./precomputed.html', import.meta.url)),
       },
     },


### PR DESCRIPTION
## Motivation

PR #344 adds production browser entry points and a React Native package smoke test, but the existing browser package check stops after TypeScript and Vite compilation. A package can build successfully while failing when its production output is loaded in a real browser, especially around package exports, initialization order, runtime globals, and capability-specific entry points.

This PR is stacked on #344 to close that runtime coverage gap before those browser APIs merge.

## Changes

- add a Playwright Chromium smoke test to the isolated Vite test app
- build and serve separate pages for the full and `/precomputed` browser entry points from packed core/browser tarballs
- exercise protobuf configuration parsing, round-trip serialization, boolean and integer evaluation, and SHA-256 matching through the full entry point
- rerun the full entry point with `TextEncoder`, `TextDecoder`, and `BigInt` unavailable
- verify the precomputed entry point parses and round-trips precomputed data without retaining rules
- fail on browser page exceptions and `console.error` output
- update the package-install check to install only the Chromium headless shell, execute the smoke tests, and restore the root lockfile after temporary package wiring

## Decisions

- keep this stacked on `sameerank/FFL-2835/configuration-from-string` because it directly tests the APIs introduced by #344
- test packed artifacts through a production Vite build and preview server rather than workspace links or a DOM emulator
- keep the existing module-level assertion as the proof that `/precomputed` excludes Protobuf-ES; this browser smoke complements it by proving the entry point executes correctly
- install only Chromium's headless shell to limit CI download size while retaining the real browser runtime boundary

## Validation

- `yarn build`
- `yarn lint`
- `yarn format:check`
- `yarn test`
- `yarn test:browser-install` (3 Playwright tests passed)